### PR TITLE
fix p2p incompatible forks for opbnb testnet and mainnet

### DIFF
--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -229,6 +229,10 @@ impl ForkFilter {
         forks.remove(&ForkFilterKey::Time(0));
         forks.remove(&ForkFilterKey::Block(0));
 
+        // Skip Fermat hardfork for opbnb
+        forks.remove(&ForkFilterKey::Time(1698991506));
+        forks.remove(&ForkFilterKey::Time(1701151200));
+
         let forks = forks
             .into_iter()
             // filter out forks that are pre-genesis by timestamp
@@ -250,7 +254,7 @@ impl ForkFilter {
 
         // Compute cache based on filtered forks and the current head.
         let cache = Cache::compute_cache(&forks, head);
-
+        
         // Create and return a new `ForkFilter`.
         Self { forks, head, cache }
     }

--- a/crates/ethereum-forks/src/forkid.rs
+++ b/crates/ethereum-forks/src/forkid.rs
@@ -254,7 +254,7 @@ impl ForkFilter {
 
         // Compute cache based on filtered forks and the current head.
         let cache = Cache::compute_cache(&forks, head);
-        
+
         // Create and return a new `ForkFilter`.
         Self { forks, head, cache }
     }

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -526,6 +526,10 @@ pub static OPBNB_TESTNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             (Hardfork::Regolith, ForkCondition::Timestamp(0)),
             (Hardfork::PreContractForkBlock, ForkCondition::Block(5805494)),
             (Hardfork::Fermat, ForkCondition::Timestamp(1698991506)),
+            (Hardfork::Shanghai, ForkCondition::Timestamp(1715753400)),
+            (Hardfork::Canyon, ForkCondition::Timestamp(1715753400)),
+            (Hardfork::Cancun, ForkCondition::Timestamp(1715754600)),
+            (Hardfork::Ecotone, ForkCondition::Timestamp(1715754600)),
         ]),
         base_fee_params: BaseFeeParamsKind::Variable(
             vec![(Hardfork::London, BaseFeeParams::ethereum())].into(),
@@ -963,6 +967,11 @@ impl ChainSpec {
         }) {
             let cond = ForkCondition::Timestamp(timestamp);
             if cond.active_at_head(head) {
+                // Skip Fermat hardfork for opbnb
+                if timestamp == 1698991506 || timestamp == 1701151200 {
+                    continue;
+                }
+
                 if timestamp != current_applied {
                     forkhash += timestamp;
                     current_applied = timestamp;


### PR DESCRIPTION
opbnb introduced the Fermat hardfork during the hardfork setup. Unlike traditional hardforks, Fermat hardfork does not have Block or Time suffixes. While op-geth ignores this hardfork in its forkid calculation, reth includes it, causing mismatched forkids and connectivity issues during P2P connections.
![image](https://github.com/bnb-chain/reth/assets/90749943/e4a4fa9f-6287-42dc-a444-2a38ae64254a)

To address this, a temporary solution has been implemented to adjust reth's forkid calculation logic by excluding the Fermat hardfork from the computation.