### PR TITLE
feat: add `sidecars` field to `Block`, `SealedBlock` and `BlockBody`

### DIFF
--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -366,6 +366,7 @@ impl StorageInner {
             body: transactions,
             ommers: ommers.clone(),
             withdrawals: withdrawals.clone(),
+            sidecars: None,
         }
         .with_recovered_senders()
         .ok_or(BlockExecutionError::Validation(BlockValidationError::SenderRecoveryError))?;
@@ -406,7 +407,7 @@ impl StorageInner {
         );
 
         let Block { mut header, body, .. } = block.block;
-        let body = BlockBody { transactions: body, ommers, withdrawals };
+        let body = BlockBody { transactions: body, ommers, withdrawals, sidecars: None };
 
         trace!(target: "consensus::auto", ?bundle_state, ?header, ?body, "executed block, calculating state root and completing header");
 

--- a/crates/consensus/auto-seal/src/task.rs
+++ b/crates/consensus/auto-seal/src/task.rs
@@ -201,6 +201,7 @@ where
                                 body: transactions,
                                 ommers,
                                 withdrawals,
+                                sidecars: None
                             };
                             let sealed_block = block.seal_slow();
 

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -232,6 +232,7 @@ impl FromReader for FileClient {
                         transactions: block.body,
                         ommers: block.ommers,
                         withdrawals: block.withdrawals,
+                        sidecars: None, // TODO: add sidecars
                     },
                 );
 

--- a/crates/net/eth-wire-types/src/blocks.rs
+++ b/crates/net/eth-wire-types/src/blocks.rs
@@ -433,6 +433,7 @@ mod tests {
                         },
                     ],
                     withdrawals: None,
+                    sidecars: None
                 }
             ]),
         };
@@ -507,6 +508,7 @@ mod tests {
                         },
                     ],
                     withdrawals: None,
+                    sidecars: None
                 }
             ]),
         };

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -162,10 +162,12 @@ where
 
         for hash in request.0 {
             if let Some(block) = self.client.block_by_hash(hash).unwrap_or_default() {
+                // TODO: get sidecars
                 let body = BlockBody {
                     transactions: block.body,
                     ommers: block.ommers,
                     withdrawals: block.withdrawals,
+                    sidecars: None,
                 };
 
                 total_bytes += body.length();

--- a/crates/node-core/src/utils.rs
+++ b/crates/node-core/src/utils.rs
@@ -120,6 +120,7 @@ where
         body: block.transactions,
         ommers: block.ommers,
         withdrawals: block.withdrawals,
+        sidecars: block.sidecars,
     };
 
     validate_block_standalone(&block, &chain_spec)?;

--- a/crates/payload/ethereum/src/lib.rs
+++ b/crates/payload/ethereum/src/lib.rs
@@ -177,7 +177,7 @@ where
             parent_beacon_block_root: attributes.parent_beacon_block_root,
         };
 
-        let block = Block { header, body: vec![], ommers: vec![], withdrawals };
+        let block = Block { header, body: vec![], ommers: vec![], withdrawals, sidecars: None };
         let sealed_block = block.seal_slow();
 
         Ok(EthBuiltPayload::new(attributes.payload_id(), sealed_block, U256::ZERO))
@@ -428,7 +428,7 @@ where
     };
 
     // seal the block
-    let block = Block { header, body: executed_txs, ommers: vec![], withdrawals };
+    let block = Block { header, body: executed_txs, ommers: vec![], withdrawals, sidecars: None };
 
     let sealed_block = block.seal_slow();
     debug!(target: "payload_builder", ?sealed_block, "sealed built block");

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Address, Bytes, GotExpected, Header, SealedHeader, TransactionSigned,
+    Address, BlobSidecars, Bytes, GotExpected, Header, SealedHeader, TransactionSigned,
     TransactionSignedEcRecovered, Withdrawals, B256,
 };
 use alloy_rlp::{RlpDecodable, RlpEncodable};
@@ -45,6 +45,14 @@ pub struct Block {
         proptest(strategy = "proptest::option::of(proptest::arbitrary::any::<Withdrawals>())")
     )]
     pub withdrawals: Option<Withdrawals>,
+
+    // only for bsc
+    /// Tx sidecars for the block.
+    #[cfg_attr(
+        any(test, feature = "arbitrary"),
+        proptest(strategy = "proptest::option::of(proptest::arbitrary::any::<BlobSidecars>())")
+    )]
+    pub sidecars: Option<BlobSidecars>,
 }
 
 impl Block {
@@ -55,6 +63,7 @@ impl Block {
             body: self.body,
             ommers: self.ommers,
             withdrawals: self.withdrawals,
+            sidecars: self.sidecars,
         }
     }
 
@@ -67,6 +76,7 @@ impl Block {
             body: self.body,
             ommers: self.ommers,
             withdrawals: self.withdrawals,
+            sidecars: self.sidecars,
         }
     }
 
@@ -183,11 +193,13 @@ impl TryFrom<alloy_rpc_types::Block> for Block {
             transactions?
         };
 
+        // TODO: set sidecar to Block
         Ok(Self {
             header: block.header.try_into()?,
             body,
             ommers: Default::default(),
             withdrawals: block.withdrawals.map(Into::into),
+            sidecars: None,
         })
     }
 }
@@ -302,14 +314,23 @@ pub struct SealedBlock {
         proptest(strategy = "proptest::option::of(proptest::arbitrary::any::<Withdrawals>())")
     )]
     pub withdrawals: Option<Withdrawals>,
+
+    // only for bsc
+    /// Tx sidecars for the block.
+    #[cfg_attr(
+        any(test, feature = "arbitrary"),
+        proptest(strategy = "proptest::option::of(proptest::arbitrary::any::<BlobSidecars>())")
+    )]
+    pub sidecars: Option<BlobSidecars>,
 }
 
 impl SealedBlock {
     /// Create a new sealed block instance using the sealed header and block body.
     #[inline]
     pub fn new(header: SealedHeader, body: BlockBody) -> Self {
-        let BlockBody { transactions, ommers, withdrawals } = body;
-        Self { header, body: transactions, ommers, withdrawals }
+        // TODO: set sidecar to Block
+        let BlockBody { transactions, ommers, withdrawals, .. } = body;
+        Self { header, body: transactions, ommers, withdrawals, sidecars: None }
     }
 
     /// Header hash.
@@ -333,6 +354,7 @@ impl SealedBlock {
                 transactions: self.body,
                 ommers: self.ommers,
                 withdrawals: self.withdrawals,
+                sidecars: self.sidecars,
             },
         )
     }
@@ -388,6 +410,7 @@ impl SealedBlock {
             body: self.body,
             ommers: self.ommers,
             withdrawals: self.withdrawals,
+            sidecars: self.sidecars,
         }
     }
 
@@ -559,6 +582,10 @@ pub struct BlockBody {
     pub ommers: Vec<Header>,
     /// Withdrawals in the block.
     pub withdrawals: Option<Withdrawals>,
+
+    // only for bsc
+    /// Tx sidecars for the block.
+    pub sidecars: Option<BlobSidecars>,
 }
 
 impl BlockBody {
@@ -569,6 +596,7 @@ impl BlockBody {
             body: self.transactions.clone(),
             ommers: self.ommers.clone(),
             withdrawals: self.withdrawals.clone(),
+            sidecars: self.sidecars.clone(),
         }
     }
 
@@ -597,13 +625,21 @@ impl BlockBody {
             self.ommers.capacity() * std::mem::size_of::<Header>() +
             self.withdrawals
                 .as_ref()
-                .map_or(std::mem::size_of::<Option<Withdrawals>>(), Withdrawals::total_size)
+                .map_or(std::mem::size_of::<Option<Withdrawals>>(), Withdrawals::total_size) +
+            self.sidecars
+                .as_ref()
+                .map_or(std::mem::size_of::<Option<BlobSidecars>>(), BlobSidecars::total_size)
     }
 }
 
 impl From<Block> for BlockBody {
     fn from(block: Block) -> Self {
-        Self { transactions: block.body, ommers: block.ommers, withdrawals: block.withdrawals }
+        Self {
+            transactions: block.body,
+            ommers: block.ommers,
+            withdrawals: block.withdrawals,
+            sidecars: None,
+        }
     }
 }
 

--- a/crates/rpc/rpc-types-compat/src/engine/payload.rs
+++ b/crates/rpc/rpc-types-compat/src/engine/payload.rs
@@ -58,7 +58,14 @@ pub fn try_payload_v1_to_block(payload: ExecutionPayloadV1) -> Result<Block, Pay
         nonce: Default::default(),
     };
 
-    Ok(Block { header, body: transactions, withdrawals: None, ommers: Default::default() })
+    // TODO: add sidecars
+    Ok(Block {
+        header,
+        body: transactions,
+        withdrawals: None,
+        ommers: Default::default(),
+        sidecars: None,
+    })
 }
 
 /// Converts [ExecutionPayloadV2] to [Block]

--- a/crates/rpc/rpc/src/eth/api/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/api/pending_block.rs
@@ -263,8 +263,11 @@ impl PendingBlockEnv {
             parent_beacon_block_root,
         };
 
+        // TODO: add sidecars
+        let sidecars = None;
+
         // seal the block
-        let block = Block { header, body: executed_txs, ommers: vec![], withdrawals };
+        let block = Block { header, body: executed_txs, ommers: vec![], withdrawals, sidecars };
         Ok(SealedBlockWithSenders { block: block.seal_slow(), senders })
     }
 }

--- a/crates/stages/src/stages/bodies.rs
+++ b/crates/stages/src/stages/bodies.rs
@@ -663,6 +663,7 @@ mod tests {
                     transactions: block.body.clone(),
                     ommers: block.ommers.clone(),
                     withdrawals: block.withdrawals.clone(),
+                    sidecars: block.sidecars.clone(),
                 },
             )
         }
@@ -941,6 +942,7 @@ mod tests {
                             body: body.transactions,
                             ommers: body.ommers,
                             withdrawals: body.withdrawals,
+                            sidecars: body.sidecars,
                         }));
                     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -788,7 +788,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
             }
 
             blocks.push(SealedBlockWithSenders {
-                block: SealedBlock { header, body, ommers, withdrawals },
+                block: SealedBlock { header, body, ommers, withdrawals, sidecars: None },
                 senders,
             })
         }
@@ -1384,7 +1384,13 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
                     None => return Ok(None),
                 };
 
-                return Ok(Some(Block { header, body: transactions, ommers, withdrawals }))
+                return Ok(Some(Block {
+                    header,
+                    body: transactions,
+                    ommers,
+                    withdrawals,
+                    sidecars: None,
+                }))
             }
         }
 
@@ -1470,7 +1476,7 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
             })
             .collect();
 
-        Block { header, body, ommers, withdrawals }
+        Block { header, body, ommers, withdrawals, sidecars: None }
             // Note: we're using unchecked here because we know the block contains valid txs wrt to
             // its height and can ignore the s value check so pre EIP-2 txs are allowed
             .try_with_senders_unchecked(senders)
@@ -1489,7 +1495,7 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
                     .map(Into::into)
                     .collect()
             };
-            Ok(Block { header, body, ommers, withdrawals })
+            Ok(Block { header, body, ommers, withdrawals, sidecars: None })
         })
     }
 
@@ -1532,7 +1538,7 @@ impl<TX: DbTx> BlockReader for DatabaseProvider<TX> {
                 (body, senders)
             };
 
-            Block { header, body, ommers, withdrawals }
+            Block { header, body, ommers, withdrawals, sidecars: None }
                 .try_with_senders_unchecked(senders)
                 .map_err(|_| ProviderError::SenderRecoveryError)
         })
@@ -1605,8 +1611,6 @@ impl<TX: DbTx> TransactionsProviderExt for DatabaseProvider<TX> {
         )
     }
 }
-
-/// Calculates the hash of the given transaction
 
 impl<TX: DbTx> TransactionsProvider for DatabaseProvider<TX> {
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -108,6 +108,7 @@ pub fn genesis() -> SealedBlock {
         body: vec![],
         ommers: vec![],
         withdrawals: Some(Withdrawals::default()),
+        sidecars: None,
     }
 }
 


### PR DESCRIPTION
This pr is to add `sidecars` field to block structs for BSC 