### PR TITLE
feat: introduce Haber fork to opBNB testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5735,6 +5735,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6168,6 +6180,15 @@ checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn 2.0.65",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -8383,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "8.0.0"
-source = "git+https://github.com/bnb-chain/revm.git?rev=deb253b#deb253b578e40130daaf4fb0243244cbb56baf6e"
+source = "git+https://github.com/bnb-chain/revm.git?rev=2f38e6c#2f38e6c6f82c8c664e4302cadde0df68f6b4cfbf"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -8415,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "4.0.0"
-source = "git+https://github.com/bnb-chain/revm.git?rev=deb253b#deb253b578e40130daaf4fb0243244cbb56baf6e"
+source = "git+https://github.com/bnb-chain/revm.git?rev=2f38e6c#2f38e6c6f82c8c664e4302cadde0df68f6b4cfbf"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -8424,7 +8445,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "6.0.0"
-source = "git+https://github.com/bnb-chain/revm.git?rev=deb253b#deb253b578e40130daaf4fb0243244cbb56baf6e"
+source = "git+https://github.com/bnb-chain/revm.git?rev=2f38e6c#2f38e6c6f82c8c664e4302cadde0df68f6b4cfbf"
 dependencies = [
  "aurora-engine-modexp",
  "bls_on_arkworks",
@@ -8435,6 +8456,7 @@ dependencies = [
  "cometbft-proto",
  "k256",
  "once_cell",
+ "p256",
  "prost",
  "revm-primitives",
  "ripemd",
@@ -8446,7 +8468,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "3.1.1"
-source = "git+https://github.com/bnb-chain/revm.git?rev=deb253b#deb253b578e40130daaf4fb0243244cbb56baf6e"
+source = "git+https://github.com/bnb-chain/revm.git?rev=2f38e6c#2f38e6c6f82c8c664e4302cadde0df68f6b4cfbf"
 dependencies = [
  "alloy-primitives",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,6 +401,6 @@ similar-asserts = "1.5.0"
 test-fuzz = "5"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bnb-chain/revm.git", rev = "deb253b" }
-revm-primitives = { git = "https://github.com/bnb-chain/revm.git", rev = "deb253b" }
+revm = { git = "https://github.com/bnb-chain/revm.git", rev = "2f38e6c" }
+revm-primitives = { git = "https://github.com/bnb-chain/revm.git", rev = "2f38e6c" }
 alloy-chains = { git = "https://github.com/alloy-rs/chains.git", rev = "906d6fb" }

--- a/crates/ethereum-forks/src/hardfork.rs
+++ b/crates/ethereum-forks/src/hardfork.rs
@@ -74,6 +74,9 @@ pub enum Hardfork {
     /// Fermat
     #[cfg(all(feature = "optimism", feature = "opbnb"))]
     Fermat,
+    /// Haber
+    #[cfg(all(feature = "optimism", feature = "opbnb"))]
+    Haber,
     // ArbOS20Atlas,
 
     // Upcoming
@@ -564,6 +567,8 @@ impl FromStr for Hardfork {
             "precontractforkblock" => Hardfork::PreContractForkBlock,
             #[cfg(all(feature = "optimism", feature = "opbnb"))]
             "fermat" => Hardfork::Fermat,
+            #[cfg(all(feature = "optimism", feature = "opbnb"))]
+            "haber" => Hardfork::Haber,
             #[cfg(feature = "optimism")]
             "canyon" => Hardfork::Canyon,
             #[cfg(feature = "optimism")]

--- a/crates/primitives/src/chain/spec.rs
+++ b/crates/primitives/src/chain/spec.rs
@@ -530,6 +530,7 @@ pub static OPBNB_TESTNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             (Hardfork::Canyon, ForkCondition::Timestamp(1715753400)),
             (Hardfork::Cancun, ForkCondition::Timestamp(1715754600)),
             (Hardfork::Ecotone, ForkCondition::Timestamp(1715754600)),
+            (Hardfork::Haber, ForkCondition::Timestamp(1717048800)),
         ]),
         base_fee_params: BaseFeeParamsKind::Variable(
             vec![(Hardfork::London, BaseFeeParams::ethereum())].into(),

--- a/crates/primitives/src/revm/config.rs
+++ b/crates/primitives/src/revm/config.rs
@@ -10,7 +10,9 @@ pub fn revm_spec_by_timestamp_after_merge(
 ) -> revm_primitives::SpecId {
     #[cfg(feature = "optimism")]
     if chain_spec.is_optimism() {
-        return if chain_spec.fork(Hardfork::Ecotone).active_at_timestamp(timestamp) {
+        return if chain_spec.fork(Hardfork::Haber).active_at_timestamp(timestamp) {
+            revm_primitives::HABER
+        } else if chain_spec.fork(Hardfork::Ecotone).active_at_timestamp(timestamp) {
             revm_primitives::ECOTONE
         } else if chain_spec.fork(Hardfork::Canyon).active_at_timestamp(timestamp) {
             revm_primitives::CANYON
@@ -36,7 +38,9 @@ pub fn revm_spec_by_timestamp_after_merge(
 pub fn revm_spec(chain_spec: &ChainSpec, block: Head) -> revm_primitives::SpecId {
     #[cfg(feature = "optimism")]
     if chain_spec.is_optimism() {
-        if chain_spec.fork(Hardfork::Ecotone).active_at_head(&block) {
+        if chain_spec.fork(Hardfork::Haber).active_at_head(&block) {
+            return revm_primitives::HABER
+        } else if chain_spec.fork(Hardfork::Ecotone).active_at_head(&block) {
             return revm_primitives::ECOTONE
         } else if chain_spec.fork(Hardfork::Canyon).active_at_head(&block) {
             return revm_primitives::CANYON


### PR DESCRIPTION
### Description
This PR is intended to support the opBNB Haber fork.

The `Haber` fork is already enabled on opBNB testnet on `May 30, 2024, at 6:00 AM UTC.`
and opBNB mainnet will enable on `2024-06-20 08:30:00 AM UTC`
 


### Rationale
https://github.com/bnb-chain/op-geth/releases/tag/v0.4.1
https://github.com/bnb-chain/op-geth/releases/tag/v0.4.2

[https://github.com/bnb-chain/op-geth/pull/112
https://github.com/bluealloy/revm/pull/1436/files](https://github.com/bnb-chain/revm/pull/26)


### Example
n/a


### Changes
1. support `opBNB` Haber Fork


Notable changes: 

* `secp256r1` verify supported on opBNB Haber fork.


### Potential Impacts

* no