### PR TITLE
feat: enable `Shanghai`, `Canyon`, `Cancun`, `Ecotone`, `Haber` on opBNB mainnet

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -603,6 +603,12 @@ pub static OPBNB_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             (Hardfork::Bedrock, ForkCondition::Block(0)),
             (Hardfork::Regolith, ForkCondition::Timestamp(0)),
             (Hardfork::Fermat, ForkCondition::Timestamp(1701151200)),
+            (Hardfork::Shanghai, ForkCondition::Timestamp(1718870400)), /* Jun-20-2024 08:00 AM
+                                                                         * +UTC */
+            (Hardfork::Canyon, ForkCondition::Timestamp(1718870400)), // Jun-20-2024 08:00 AM +UTC
+            (Hardfork::Cancun, ForkCondition::Timestamp(1718871600)), // Jun-20-2024 08:20 AM +UTC
+            (Hardfork::Ecotone, ForkCondition::Timestamp(1718871600)), // Jun-20-2024 08:20 AM +UTC
+            (Hardfork::Haber, ForkCondition::Timestamp(1718871600)),  // Jun-20-2024 08:20 AM +UTC
         ]),
         base_fee_params: BaseFeeParamsKind::Variable(
             vec![(Hardfork::London, BaseFeeParams::ethereum())].into(),

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -608,7 +608,7 @@ pub static OPBNB_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
             (Hardfork::Canyon, ForkCondition::Timestamp(1718870400)), // Jun-20-2024 08:00 AM +UTC
             (Hardfork::Cancun, ForkCondition::Timestamp(1718871600)), // Jun-20-2024 08:20 AM +UTC
             (Hardfork::Ecotone, ForkCondition::Timestamp(1718871600)), // Jun-20-2024 08:20 AM +UTC
-            (Hardfork::Haber, ForkCondition::Timestamp(1718871600)),  // Jun-20-2024 08:20 AM +UTC
+            (Hardfork::Haber, ForkCondition::Timestamp(1718872200)),  // Jun-20-2024 08:30 AM +UTC
         ]),
         base_fee_params: BaseFeeParamsKind::Variable(
             vec![(Hardfork::London, BaseFeeParams::ethereum())].into(),


### PR DESCRIPTION
### Description
Enable `Shanghai`, `Canyon`, `Cancun`, `Ecotone`, `Haber` on opBNB mainnet)

### Rationale

[op-geth](https://github.com/bnb-chain/op-geth/blob/03809432dab1a7057e5c31f101673d30fe9ec079/params/config.go#L198)

### Example

n/a

### Changes

Notable changes: 
* enable hardfork on opBNB mainnet

### Potential Impacts
* no
