### PR TITLE
fix: base fee configuration of bsc

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -166,7 +166,7 @@ bsc = [
     "dep:reth-node-bsc",
     "reth-node-core/bsc",
     "reth-stages/bsc",
-    "reth-node-builder/bsc"
+    "reth-node-builder/bsc",
 ]
 
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices

--- a/crates/bsc/consensus/Cargo.toml
+++ b/crates/bsc/consensus/Cargo.toml
@@ -59,4 +59,7 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 rand = "0.8.5"
 
 [features]
-bsc = ["reth-primitives/bsc"]
+bsc = [
+    "reth-primitives/bsc",
+    "reth-consensus-common/bsc"
+]

--- a/crates/bsc/consensus/src/lib.rs
+++ b/crates/bsc/consensus/src/lib.rs
@@ -791,7 +791,6 @@ mod tests {
         assert_eq!(storage.headers.get(&block.number), Some(&block));
         assert_eq!(storage.hash_to_number.get(&block.hash()), Some(&block.number));
         assert_eq!(storage.bodies.get(&block.hash()), Some(&BlockBody::default()));
-        assert_eq!(storage.block_hash(block.number), Some(block.hash()));
         assert_eq!(
             storage.header_by_hash_or_number(BlockHashOrNumber::Hash(block.hash())),
             Some(block.clone())

--- a/crates/bsc/node/Cargo.toml
+++ b/crates/bsc/node/Cargo.toml
@@ -49,4 +49,5 @@ bsc = [
     "reth-evm-bsc/bsc",
     "reth-primitives/bsc",
     "reth-config/bsc",
+    "reth-bsc-consensus/bsc",
 ]

--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -20,3 +20,6 @@ reth-consensus.workspace = true
 reth-storage-api.workspace = true
 rand.workspace = true
 mockall = "0.12"
+
+[features]
+bsc = ["reth-chainspec/bsc"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -129,6 +129,7 @@ opbnb = [
     "revm/opbnb",
 ]
 bsc = [
+    "reth-primitives-traits/bsc",
     "reth-chainspec/bsc",
     "reth-ethereum-forks/bsc",
     "revm/bsc",


### PR DESCRIPTION
### Description

fix base fee configuration of bsc
```
2024-06-24T01:03:00.736652Z TRACE downloaders::headers: Failed to validate header error=failed to validate header 0xd00b1a1ae5f0a03868c2ef0cd96199ad45081c194ad825147ea0d105def8ca3d, block number 31103030: block base fee mismatch: got 0, expected 1000000000
2024-06-24T01:03:00.736713Z TRACE downloaders::headers: Penalizing peer peer_id=0x0637d1e62026e0c8685b1db0ca1c767c78c95c3fab64abc468d1a64b12ca4b530b46b8f80c915aec96f74f7ffc5999e8ad6d1484476f420f0c10e3d42361914b error=failed to validate header 0xd00b1a1ae5f0a03868c2ef0cd96199ad45081c194ad825147ea0d105def8ca3d, block number 31103030: block base fee mismatch: got 0, expected 1000000000
```

### Rationale
`reth-primitives-traits` was not enabled with `bsc` feature.

### Example

n/a

### Changes

Notable changes: 
* cargo config

### Potential Impacts
* no
