### PR TITLE
feat: add bootnodes for opbnb

### DIFF
--- a/crates/chainspec/src/net.rs
+++ b/crates/chainspec/src/net.rs
@@ -92,6 +92,20 @@ pub static BSC_TESTNET_BOOTNODES: &[&str] = &[
     "enode://665cf77ca26a8421cfe61a52ac312958308d4912e78ce8e0f61d6902e4494d4cc38f9b0dd1b23a427a7a5734e27e5d9729231426b06bb9c73b56a142f83f6b68@52.72.123.113:30311",
 ];
 
+#[cfg(all(feature = "optimism", feature = "opbnb"))]
+/// OPBNB testnet boot nodes.
+pub static OPBNB_MAINNET_BOOTNODES: &[&str] = &[
+    "enode://db109c6cac5c8b6225edd3176fc3764c58e0720950fe94c122c80978e706a9c9e976629b718e48b6306ea0f9126e5394d3424c9716c5703549e2e7eba216353b@52.193.218.151:30304",
+    "enode://afe18782053bb31fb7ea41e1acf659ab9bd1eec181fb97331f0a6b61871a469b4f75138f903c977796be1cc2a3c985d33150a396e878d3cd6e4723b6040ff9c0@52.195.105.192:30304",
+];
+
+#[cfg(all(feature = "optimism", feature = "opbnb"))]
+/// OPBNB testnet boot nodes.
+pub static OPBNB_TESTNET_BOOTNODES: &[&str] = &[
+    "enode://217cfe091047a1c3f490e96d51e2f3bd90517a9be77b8a6033b31833a193aa6c33b6d07088c4980f462162635ffbccaa413dc28cb14c4f2b96af0dd97292411f@13.112.117.88:30304",
+    "enode://38c8913f87d64179bac23514ddb56a17f5b28f7e253b3825a10a2c8b9553c5df7d3b6c83a96948ad0466f384bf63236fd5e6bed6d6402156749b6b0899c82d47@54.199.235.83:30304",
+];
+
 /// Returns parsed mainnet nodes
 pub fn mainnet_nodes() -> Vec<NodeRecord> {
     parse_nodes(&MAINNET_BOOTNODES[..])
@@ -122,6 +136,18 @@ pub fn op_nodes() -> Vec<NodeRecord> {
 /// Returns parsed op-stack testnet nodes
 pub fn op_testnet_nodes() -> Vec<NodeRecord> {
     parse_nodes(OP_TESTNET_BOOTNODES)
+}
+
+#[cfg(all(feature = "optimism", feature = "opbnb"))]
+/// Returns parsed opbnb testnet nodes
+pub fn opbnb_testnet_nodes() -> Vec<NodeRecord> {
+    parse_nodes(OPBNB_TESTNET_BOOTNODES)
+}
+
+#[cfg(all(feature = "optimism", feature = "opbnb"))]
+/// Returns parsed opbnb mainnet nodes
+pub fn opbnb_mainnet_nodes() -> Vec<NodeRecord> {
+    parse_nodes(OPBNB_MAINNET_BOOTNODES)
 }
 
 #[cfg(feature = "optimism")]

--- a/crates/chainspec/src/net.rs
+++ b/crates/chainspec/src/net.rs
@@ -93,7 +93,7 @@ pub static BSC_TESTNET_BOOTNODES: &[&str] = &[
 ];
 
 #[cfg(all(feature = "optimism", feature = "opbnb"))]
-/// OPBNB testnet boot nodes.
+/// OPBNB mainnet boot nodes.
 pub static OPBNB_MAINNET_BOOTNODES: &[&str] = &[
     "enode://db109c6cac5c8b6225edd3176fc3764c58e0720950fe94c122c80978e706a9c9e976629b718e48b6306ea0f9126e5394d3424c9716c5703549e2e7eba216353b@52.193.218.151:30304",
     "enode://afe18782053bb31fb7ea41e1acf659ab9bd1eec181fb97331f0a6b61871a469b4f75138f903c977796be1cc2a3c985d33150a396e878d3cd6e4723b6040ff9c0@52.195.105.192:30304",

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -146,9 +146,7 @@ pub static BSC_TESTNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
 });
 
 #[cfg(all(feature = "optimism", feature = "opbnb"))]
-pub(crate) use crate::net::{
-    opbnb_testnet_nodes, opbnb_mainnet_nodes,
-};
+pub(crate) use crate::net::{opbnb_testnet_nodes, opbnb_mainnet_nodes};
 
 /// The Ethereum mainnet spec
 pub static MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -146,7 +146,7 @@ pub static BSC_TESTNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
 });
 
 #[cfg(all(feature = "optimism", feature = "opbnb"))]
-pub(crate) use crate::net::{opbnb_testnet_nodes, opbnb_mainnet_nodes};
+pub(crate) use crate::net::{opbnb_mainnet_nodes, opbnb_testnet_nodes};
 
 /// The Ethereum mainnet spec
 pub static MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -145,6 +145,11 @@ pub static BSC_TESTNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
     .into()
 });
 
+#[cfg(all(feature = "optimism", feature = "opbnb"))]
+pub(crate) use crate::net::{
+    opbnb_testnet_nodes, opbnb_mainnet_nodes,
+};
+
 /// The Ethereum mainnet spec
 pub static MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
     ChainSpec {
@@ -1165,6 +1170,10 @@ impl ChainSpec {
             C::BNBSmartChain => Some(bsc_mainnet_nodes()),
             #[cfg(feature = "bsc")]
             C::BNBSmartChainTestnet => Some(bsc_testnet_nodes()),
+            #[cfg(all(feature = "optimism", feature = "opbnb"))]
+            C::OpBNBTestnet => Some(opbnb_testnet_nodes()),
+            #[cfg(all(feature = "optimism", feature = "opbnb"))]
+            C::OpBNBMainnet => Some(opbnb_mainnet_nodes()),
             _ => None,
         }
     }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -132,7 +132,7 @@ mod optimism {
     };
     #[cfg(feature = "opbnb")]
     pub use reth_chainspec::{
-        net::{opbnb_testnet_nodes, opbnb_mainnet_nodes},
+        net::{opbnb_mainnet_nodes, opbnb_testnet_nodes},
         OPBNB_MAINNET, OPBNB_TESTNET,
     };
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -131,7 +131,12 @@ mod optimism {
         BASE_MAINNET, BASE_SEPOLIA, OP_MAINNET, OP_SEPOLIA,
     };
     #[cfg(feature = "opbnb")]
-    pub use reth_chainspec::{OPBNB_MAINNET, OPBNB_TESTNET};
+    pub use reth_chainspec::{
+        net::{
+            opbnb_testnet_nodes, opbnb_mainnet_nodes,
+        },
+        OPBNB_MAINNET, OPBNB_TESTNET,
+    };
 }
 
 #[cfg(feature = "optimism")]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -132,9 +132,7 @@ mod optimism {
     };
     #[cfg(feature = "opbnb")]
     pub use reth_chainspec::{
-        net::{
-            opbnb_testnet_nodes, opbnb_mainnet_nodes,
-        },
+        net::{opbnb_testnet_nodes, opbnb_mainnet_nodes},
         OPBNB_MAINNET, OPBNB_TESTNET,
     };
 }


### PR DESCRIPTION
### Description

This pr will add boot nodes for opbnb's testnet and mainnet. The users can start the nodes without specifying boot nodes anymore.

For example, the users can start a opbnb testnet node with command:
```
export L2_RPC=https://opbnb-testnet-rpc.bnbchain.org

./op-reth node \
    --datadir=./datadir \
    --chain=opbnb-testnet \
    --rollup.sequencer-http=${L2_RPC} \
    --authrpc.addr="0.0.0.0" \
    --authrpc.port=8551 \
    --authrpc.jwtsecret=./jwt.txt \
    --http \
    --http.addr=0.0.0.0 \
    --http.port=8545 \
    --http.api="admin, debug, eth, net, trace, txpool, web3, rpc, reth, ots, eth-call-bundle" \
    --ws \
    --ws.addr=0.0.0.0 \
    --ws.port=8546 \
    --builder.gaslimit=150000000 \
    --nat=any \
    -vvvvv \
    --port=50503 \
    --discovery.v5.port=9320 \
    --debug.tip 0x7b608e5fab643194aa762859d5f7d5a52f8dd72587016102a6e860b2c55b3b48 \
```

### Rationale

To add boot nodes for opbnb's testnet and mainnet.

### Example

n/a

### Changes

Notable changes: 
* add bootnodes for opbnb

### Potential Impacts
n/a