### PR TITLE
feat: add docker file for optimism and opbnb

### DIFF
--- a/op.Dockerfile
+++ b/op.Dockerfile
@@ -36,7 +36,7 @@ RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin o
 
 # ARG is not resolved in COPY so we have to hack around it by copying the
 # binary to a temporary location
-RUN cp /app/target/$BUILD_PROFILE/op-reth /app/bsc-reth
+RUN cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth
 
 # Use Ubuntu as the release image
 FROM ubuntu AS runtime
@@ -49,4 +49,4 @@ COPY --from=builder /app/bsc-reth /usr/local/bin
 COPY LICENSE-* ./
 
 EXPOSE 30303 30303/udp 9001 8545 8546
-ENTRYPOINT ["/usr/local/bin/bsc-reth"]
+ENTRYPOINT ["/usr/local/bin/op-reth"]

--- a/op.Dockerfile
+++ b/op.Dockerfile
@@ -1,0 +1,52 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
+LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
+
+# Builds a cargo-chef plan
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+
+# Build profile, release by default
+ARG BUILD_PROFILE=release
+ENV BUILD_PROFILE $BUILD_PROFILE
+
+# Extra Cargo flags
+ARG RUSTFLAGS=""
+ENV RUSTFLAGS "$RUSTFLAGS"
+
+# Extra Cargo features
+ARG FEATURES="optimism"
+ENV FEATURES $FEATURES
+
+# Install system dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+
+# Builds dependencies
+RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json
+
+# Build application
+COPY . .
+RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin op-reth
+
+# ARG is not resolved in COPY so we have to hack around it by copying the
+# binary to a temporary location
+RUN cp /app/target/$BUILD_PROFILE/op-reth /app/bsc-reth
+
+# Use Ubuntu as the release image
+FROM ubuntu AS runtime
+WORKDIR /app
+
+# Copy reth over from the build stage
+COPY --from=builder /app/bsc-reth /usr/local/bin
+
+# Copy licenses
+COPY LICENSE-* ./
+
+EXPOSE 30303 30303/udp 9001 8545 8546
+ENTRYPOINT ["/usr/local/bin/bsc-reth"]


### PR DESCRIPTION
### Description

This pr will add a docker file for optimism and opbnb.

### Rationale

To add a docker file for optimism and opbnb.

### Example

```
docker build  --build-arg FEATURES="optimism opbnb" -f op.Dockerfile . -t op-reth
```

### Changes

Notable changes: 
* add docker file for optimism and opbnb

### Potential Impacts
* n/a