### PR TITLE
fix: disable parlia task if running with debug.tip

### DIFF
--- a/crates/bsc/consensus/src/lib.rs
+++ b/crates/bsc/consensus/src/lib.rs
@@ -637,7 +637,7 @@ where
 
     /// Consumes the type and returns all components
     #[track_caller]
-    pub fn build(self) -> ParliaClient {
+    pub fn build(self, start_engine_task: bool) -> ParliaClient {
         let Self {
             chain_spec,
             cfg,
@@ -648,16 +648,18 @@ where
             client,
         } = self;
         let parlia_client = ParliaClient::new(storage.clone(), fetch_client);
-        ParliaEngineTask::start(
-            chain_spec.clone(),
-            Parlia::new(chain_spec, cfg.clone()),
-            client,
-            to_engine,
-            network_block_event_rx,
-            storage,
-            parlia_client.clone(),
-            cfg.period,
-        );
+        if start_engine_task {
+            ParliaEngineTask::start(
+                chain_spec.clone(),
+                Parlia::new(chain_spec, cfg.clone()),
+                client,
+                to_engine,
+                network_block_event_rx,
+                storage,
+                parlia_client.clone(),
+                cfg.period,
+            );
+        }
         parlia_client
     }
 }

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -280,7 +280,8 @@ where
                     consensus_engine_tx.clone(),
                     engine_rx,
                     network_client.clone(),
-                ).build(ctx.node_config().debug.tip.is_none());
+                ).
+                build(ctx.node_config().debug.tip.is_none());
                 (pipeline, Either::Right(client))
             }
             #[cfg(not(feature = "bsc"))]

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -280,8 +280,8 @@ where
                     consensus_engine_tx.clone(),
                     engine_rx,
                     network_client.clone(),
-                ).
-                build(ctx.node_config().debug.tip.is_none());
+                )
+                .build(ctx.node_config().debug.tip.is_none());
                 (pipeline, Either::Right(client))
             }
             #[cfg(not(feature = "bsc"))]

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -280,8 +280,7 @@ where
                     consensus_engine_tx.clone(),
                     engine_rx,
                     network_client.clone(),
-                )
-                .build();
+                ).build(ctx.node_config().debug.tip.is_none());
                 (pipeline, Either::Right(client))
             }
             #[cfg(not(feature = "bsc"))]


### PR DESCRIPTION
### Description

disable parlia task if running with debug.tip

### Rationale

parlia engine task is unnecessary for debug mode

### Example

n/a

### Changes

Notable changes: 
* launch/mod.rs

### Potential Impacts
no
