### PR TITLE
feat: add trie prefetch when executing blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8134,7 +8134,6 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-storage-errors",
- "reth-trie",
  "revm",
  "revm-primitives",
  "tokio",
@@ -8158,7 +8157,6 @@ dependencies = [
  "reth-provider",
  "reth-prune-types",
  "reth-revm",
- "reth-trie",
  "revm-primitives",
  "thiserror",
  "tokio",
@@ -8180,7 +8178,6 @@ dependencies = [
  "reth-prune-types",
  "reth-revm",
  "reth-testing-utils",
- "reth-trie",
  "revm-primitives",
  "secp256k1",
  "serde_json",
@@ -8202,7 +8199,6 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-revm",
- "reth-trie",
  "revm",
  "revm-primitives",
  "thiserror",
@@ -9804,7 +9800,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-prefetch"
-version = "1.0.3"
+version = "1.0.2"
 dependencies = [
  "alloy-rlp",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7292,6 +7292,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-trie",
  "reth-trie-parallel",
+ "reth-trie-prefetch",
  "tokio",
  "tracing",
 ]
@@ -8133,8 +8134,10 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-storage-errors",
+ "reth-trie",
  "revm",
  "revm-primitives",
+ "tokio",
 ]
 
 [[package]]
@@ -8155,8 +8158,10 @@ dependencies = [
  "reth-provider",
  "reth-prune-types",
  "reth-revm",
+ "reth-trie",
  "revm-primitives",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 
@@ -8175,9 +8180,12 @@ dependencies = [
  "reth-prune-types",
  "reth-revm",
  "reth-testing-utils",
+ "reth-trie",
  "revm-primitives",
  "secp256k1",
  "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -8194,9 +8202,11 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-revm",
+ "reth-trie",
  "revm",
  "revm-primitives",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 
@@ -9787,6 +9797,30 @@ dependencies = [
  "reth-provider",
  "reth-tasks",
  "reth-trie",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-trie-prefetch"
+version = "1.0.3"
+dependencies = [
+ "alloy-rlp",
+ "criterion",
+ "derive_more",
+ "metrics",
+ "proptest",
+ "rand 0.8.5",
+ "rayon",
+ "reth-db",
+ "reth-execution-errors",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-provider",
+ "reth-tasks",
+ "reth-trie",
+ "reth-trie-parallel",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ members = [
     "crates/transaction-pool/",
     "crates/trie/common",
     "crates/trie/parallel/",
+    "crates/trie/prefetch/",
     "crates/trie/trie",
     "crates/bsc/node/",
     "crates/bsc/engine/",
@@ -384,6 +385,7 @@ reth-trie = { path = "crates/trie/trie" }
 reth-trie-common = { path = "crates/trie/common" }
 reth-trie-db = { path = "crates/trie/db" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
+reth-trie-prefetch = { path = "crates/trie/prefetch" }
 
 # revm
 revm = { version = "12.1.0", features = [

--- a/Makefile
+++ b/Makefile
@@ -53,14 +53,14 @@ install: ## Build and install the reth binary under `~/.cargo/bin`.
 .PHONY: install-op
 install-op: ## Build and install the op-reth binary under `~/.cargo/bin`.
 	cargo install --path bin/reth --bin op-reth --force --locked \
-		--features "optimism opbnb $(FEATURES)" \
+		--features "optimism,opbnb,$(FEATURES)" \
 		--profile "$(PROFILE)" \
 		$(CARGO_INSTALL_EXTRA_FLAGS)
 
 .PHONY: install-bsc
 install-bsc: ## Build and install the bsc-reth binary under `~/.cargo/bin`.
 	cargo install --path bin/reth --bin bsc-reth --force --locked \
-		--features "bsc $(FEATURES)" \
+		--features "bsc,prefetch,$(FEATURES)" \
 		--profile "$(PROFILE)" \
 		$(CARGO_INSTALL_EXTRA_FLAGS)
 
@@ -70,11 +70,11 @@ build: ## Build the reth binary into `target` directory.
 
 .PHONY: build-op
 build-op: ## Build the op-reth binary into `target` directory.
-	cargo build --bin op-reth --features "optimism opbnb $(FEATURES)" --profile "$(PROFILE)"
+	cargo build --bin op-reth --features "optimism,opbnb,$(FEATURES)" --profile "$(PROFILE)"
 
 .PHONY: build-bsc
 build-bsc: ## Build the bsc-reth binary into `target` directory.
-	cargo build --bin bsc-reth --features "bsc $(FEATURES)" --profile "$(PROFILE)"
+	cargo build --bin bsc-reth --features "bsc,prefetch,$(FEATURES)" --profile "$(PROFILE)"
 
 # Builds the reth binary natively.
 build-native-%:
@@ -84,7 +84,7 @@ op-build-native-%:
 	cargo build --bin op-reth --target $* --features "optimism,opbnb,$(FEATURES)" --profile "$(PROFILE)"
 
 bsc-build-native-%:
-	cargo build --bin bsc-reth --target $* --features "bsc,$(FEATURES)" --profile "$(PROFILE)"
+	cargo build --bin bsc-reth --target $* --features "bsc,prefetch,$(FEATURES)" --profile "$(PROFILE)"
 
 # The following commands use `cross` to build a cross-compile.
 #
@@ -127,7 +127,7 @@ op-build-%:
 
 bsc-build-%:
 	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-		cross build --bin bsc-reth --target $* --features "bsc,$(FEATURES)" --profile "$(PROFILE)"
+		cross build --bin bsc-reth --target $* --features "bsc,prefetch,$(FEATURES)" --profile "$(PROFILE)"
 
 # Unfortunately we can't easily use cross to build for Darwin because of licensing issues.
 # If we wanted to, we would need to build a custom Docker image with the SDK available.

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ install-op: ## Build and install the op-reth binary under `~/.cargo/bin`.
 .PHONY: install-bsc
 install-bsc: ## Build and install the bsc-reth binary under `~/.cargo/bin`.
 	cargo install --path bin/reth --bin bsc-reth --force --locked \
-		--features "bsc,prefetch,$(FEATURES)" \
+		--features "bsc,$(FEATURES)" \
 		--profile "$(PROFILE)" \
 		$(CARGO_INSTALL_EXTRA_FLAGS)
 
@@ -74,7 +74,7 @@ build-op: ## Build the op-reth binary into `target` directory.
 
 .PHONY: build-bsc
 build-bsc: ## Build the bsc-reth binary into `target` directory.
-	cargo build --bin bsc-reth --features "bsc,prefetch,$(FEATURES)" --profile "$(PROFILE)"
+	cargo build --bin bsc-reth --features "bsc,$(FEATURES)" --profile "$(PROFILE)"
 
 # Builds the reth binary natively.
 build-native-%:
@@ -84,7 +84,7 @@ op-build-native-%:
 	cargo build --bin op-reth --target $* --features "optimism,opbnb,$(FEATURES)" --profile "$(PROFILE)"
 
 bsc-build-native-%:
-	cargo build --bin bsc-reth --target $* --features "bsc,prefetch,$(FEATURES)" --profile "$(PROFILE)"
+	cargo build --bin bsc-reth --target $* --features "bsc,$(FEATURES)" --profile "$(PROFILE)"
 
 # The following commands use `cross` to build a cross-compile.
 #
@@ -127,7 +127,7 @@ op-build-%:
 
 bsc-build-%:
 	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-		cross build --bin bsc-reth --target $* --features "bsc,prefetch,$(FEATURES)" --profile "$(PROFILE)"
+		cross build --bin bsc-reth --target $* --features "bsc,$(FEATURES)" --profile "$(PROFILE)"
 
 # Unfortunately we can't easily use cross to build for Darwin because of licensing issues.
 # If we wanted to, we would need to build a custom Docker image with the SDK available.

--- a/Makefile
+++ b/Makefile
@@ -53,14 +53,14 @@ install: ## Build and install the reth binary under `~/.cargo/bin`.
 .PHONY: install-op
 install-op: ## Build and install the op-reth binary under `~/.cargo/bin`.
 	cargo install --path bin/reth --bin op-reth --force --locked \
-		--features "optimism,opbnb,$(FEATURES)" \
+		--features "optimism opbnb $(FEATURES)" \
 		--profile "$(PROFILE)" \
 		$(CARGO_INSTALL_EXTRA_FLAGS)
 
 .PHONY: install-bsc
 install-bsc: ## Build and install the bsc-reth binary under `~/.cargo/bin`.
 	cargo install --path bin/reth --bin bsc-reth --force --locked \
-		--features "bsc,$(FEATURES)" \
+		--features "bsc $(FEATURES)" \
 		--profile "$(PROFILE)" \
 		$(CARGO_INSTALL_EXTRA_FLAGS)
 
@@ -70,21 +70,21 @@ build: ## Build the reth binary into `target` directory.
 
 .PHONY: build-op
 build-op: ## Build the op-reth binary into `target` directory.
-	cargo build --bin op-reth --features "optimism,opbnb,$(FEATURES)" --profile "$(PROFILE)"
+	cargo build --bin op-reth --features "optimism opbnb $(FEATURES)" --profile "$(PROFILE)"
 
 .PHONY: build-bsc
 build-bsc: ## Build the bsc-reth binary into `target` directory.
-	cargo build --bin bsc-reth --features "bsc,$(FEATURES)" --profile "$(PROFILE)"
+	cargo build --bin bsc-reth --features "bsc $(FEATURES)" --profile "$(PROFILE)"
 
 # Builds the reth binary natively.
 build-native-%:
 	cargo build --bin reth --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
 
 op-build-native-%:
-	cargo build --bin op-reth --target $* --features "optimism,opbnb,$(FEATURES)" --profile "$(PROFILE)"
+	cargo build --bin op-reth --target $* --features "optimism opbnb $(FEATURES)" --profile "$(PROFILE)"
 
 bsc-build-native-%:
-	cargo build --bin bsc-reth --target $* --features "bsc,$(FEATURES)" --profile "$(PROFILE)"
+	cargo build --bin bsc-reth --target $* --features "bsc $(FEATURES)" --profile "$(PROFILE)"
 
 # The following commands use `cross` to build a cross-compile.
 #
@@ -123,11 +123,11 @@ build-%:
 
 op-build-%:
 	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-		cross build --bin op-reth --target $* --features "optimism,opbnb,$(FEATURES)" --profile "$(PROFILE)"
+		cross build --bin op-reth --target $* --features "optimism opbnb $(FEATURES)" --profile "$(PROFILE)"
 
 bsc-build-%:
 	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-		cross build --bin bsc-reth --target $* --features "bsc,$(FEATURES)" --profile "$(PROFILE)"
+		cross build --bin bsc-reth --target $* --features "bsc $(FEATURES)" --profile "$(PROFILE)"
 
 # Unfortunately we can't easily use cross to build for Darwin because of licensing issues.
 # If we wanted to, we would need to build a custom Docker image with the SDK available.

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -164,6 +164,8 @@ bsc = [
     "reth-beacon-consensus/bsc",
 ]
 
+prefetch = ["reth-blockchain-tree/prefetch"]
+
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices
 ethereum = []
 

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -164,8 +164,6 @@ bsc = [
     "reth-beacon-consensus/bsc",
 ]
 
-prefetch = ["reth-blockchain-tree/prefetch"]
-
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices
 ethereum = []
 

--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -275,9 +275,9 @@ impl Command {
                 #[cfg(feature = "bsc")]
                 let executor =
                     block_executor!(provider_factory.chain_spec(), provider_factory.clone())
-                        .executor(db);
+                        .executor(db, None);
                 #[cfg(not(feature = "bsc"))]
-                let executor = block_executor!(provider_factory.chain_spec()).executor(db);
+                let executor = block_executor!(provider_factory.chain_spec()).executor(db, None);
 
                 let BlockExecutionOutput { state, receipts, requests, .. } = executor
                     .execute((&block_with_senders.clone().unseal(), U256::MAX, None).into())?;

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -130,10 +130,10 @@ impl Command {
         ));
 
         #[cfg(feature = "bsc")]
-        let executor =
-            block_executor!(provider_factory.chain_spec(), provider_factory.clone()).executor(db);
+        let executor = block_executor!(provider_factory.chain_spec(), provider_factory.clone())
+            .executor(db, None);
         #[cfg(not(feature = "bsc"))]
-        let executor = block_executor!(provider_factory.chain_spec()).executor(db);
+        let executor = block_executor!(provider_factory.chain_spec()).executor(db, None);
 
         let merkle_block_td =
             provider.header_td_by_number(merkle_block_number)?.unwrap_or_default();

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -28,6 +28,7 @@ reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-parallel = { workspace = true, features = ["parallel"] }
 reth-network.workspace = true
 reth-consensus.workspace = true
+reth-trie-prefetch = { workspace = true, optional = true }
 
 # common
 parking_lot.workspace = true
@@ -59,3 +60,4 @@ alloy-genesis.workspace = true
 [features]
 test-utils = []
 optimism = ["reth-primitives/optimism", "reth-provider/optimism"]
+prefetch = ["dep:reth-trie-prefetch"]

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -28,7 +28,7 @@ reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-parallel = { workspace = true, features = ["parallel"] }
 reth-network.workspace = true
 reth-consensus.workspace = true
-reth-trie-prefetch = { workspace = true, optional = true }
+reth-trie-prefetch.workspace = true
 
 # common
 parking_lot.workspace = true
@@ -60,4 +60,3 @@ alloy-genesis.workspace = true
 [features]
 test-utils = []
 optimism = ["reth-primitives/optimism", "reth-provider/optimism"]
-prefetch = ["dep:reth-trie-prefetch"]

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -90,7 +90,7 @@ impl<DB, E> BlockchainTree<DB, E> {
 
 impl<DB, E> BlockchainTree<DB, E>
 where
-    DB: Database + Clone,
+    DB: Database + Clone + 'static,
     E: BlockExecutorProvider,
 {
     /// Builds the blockchain tree for the node.

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -171,7 +171,7 @@ where
     }
 
     /// Enable prefetch.
-    pub fn enable_prefetch(mut self) -> Self {
+    pub const fn enable_prefetch(mut self) -> Self {
         self.enable_prefetch = true;
         self
     }

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -72,6 +72,8 @@ pub struct BlockchainTree<DB, E> {
     sync_metrics_tx: Option<MetricEventsSender>,
     /// Metrics for the blockchain tree.
     metrics: TreeMetrics,
+    /// Whether to enable prefetch when execute block
+    enable_prefetch: bool,
 }
 
 impl<DB, E> BlockchainTree<DB, E> {
@@ -143,6 +145,7 @@ where
             canon_state_notification_sender,
             sync_metrics_tx: None,
             metrics: Default::default(),
+            enable_prefetch: false,
         })
     }
 
@@ -164,6 +167,12 @@ where
     /// synchronization process with the blockchain network.
     pub fn with_sync_metrics_tx(mut self, metrics_tx: MetricEventsSender) -> Self {
         self.sync_metrics_tx = Some(metrics_tx);
+        self
+    }
+
+    /// Enable prefetch.
+    pub fn enable_prefetch(mut self) -> Self {
+        self.enable_prefetch = true;
         self
     }
 
@@ -434,6 +443,7 @@ where
             &self.externals,
             block_attachment,
             block_validation_kind,
+            self.enable_prefetch,
         )?;
 
         self.insert_chain(chain);
@@ -491,6 +501,7 @@ where
                 canonical_fork,
                 block_attachment,
                 block_validation_kind,
+                self.enable_prefetch,
             )?;
 
             self.state.block_indices.insert_non_fork_block(block_number, block_hash, chain_id);
@@ -505,6 +516,7 @@ where
                 canonical_fork,
                 &self.externals,
                 block_validation_kind,
+                self.enable_prefetch,
             )?;
             self.insert_chain(chain);
             BlockAttachment::HistoricalFork

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -25,6 +25,10 @@ use reth_provider::{
 use reth_revm::database::StateProviderDatabase;
 use reth_trie::updates::TrieUpdates;
 use reth_trie_parallel::parallel_root::ParallelStateRoot;
+#[cfg(feature = "prefetch")]
+use reth_trie_prefetch::TriePrefetch;
+#[cfg(feature = "prefetch")]
+use std::sync::Arc;
 use std::{
     collections::{BTreeMap, HashMap},
     ops::{Deref, DerefMut},
@@ -77,7 +81,7 @@ impl AppendableChain {
         block_validation_kind: BlockValidationKind,
     ) -> Result<Self, InsertBlockErrorKind>
     where
-        DB: Database + Clone,
+        DB: Database + Clone + 'static,
         E: BlockExecutorProvider,
     {
         let execution_outcome = ExecutionOutcome::default();
@@ -116,7 +120,7 @@ impl AppendableChain {
         block_validation_kind: BlockValidationKind,
     ) -> Result<Self, InsertBlockErrorKind>
     where
-        DB: Database + Clone,
+        DB: Database + Clone + 'static,
         E: BlockExecutorProvider,
     {
         let parent_number =
@@ -181,7 +185,7 @@ impl AppendableChain {
     ) -> Result<(ExecutionOutcome, Option<TrieUpdates>), BlockExecutionError>
     where
         EDP: FullExecutionDataProvider,
-        DB: Database + Clone,
+        DB: Database + Clone + 'static,
         E: BlockExecutorProvider,
     {
         // some checks are done before blocks comes here.
@@ -208,10 +212,34 @@ impl AppendableChain {
 
         let provider = BundleStateProvider::new(state_provider, bundle_state_data_provider);
 
+        #[cfg(feature = "prefetch")]
+        let (prefetch_tx, prefetch_rx) = tokio::sync::mpsc::unbounded_channel();
+
         let db = StateProviderDatabase::new(&provider);
-        let executor = externals.executor_factory.executor(db);
+        #[cfg(feature = "prefetch")]
+        let executor = externals.executor_factory.executor(db, Some(prefetch_tx));
+        #[cfg(not(feature = "prefetch"))]
+        let executor = externals.executor_factory.executor(db, None);
+
         let block_hash = block.hash();
         let block = block.unseal();
+
+        #[cfg(feature = "prefetch")]
+        let (interrupt_tx, interrupt_rx) = tokio::sync::oneshot::channel();
+
+        #[cfg(feature = "prefetch")]
+        {
+            let mut trie_prefetch = TriePrefetch::new();
+            let consistent_view = Arc::new(ConsistentDbView::new_with_latest_tip(
+                externals.provider_factory.clone(),
+            )?);
+
+            tokio::spawn({
+                async move {
+                    trie_prefetch.run::<DB>(consistent_view, prefetch_rx, interrupt_rx).await;
+                }
+            });
+        }
 
         let state = executor.execute((&block, U256::MAX, ancestor_blocks).into())?;
         let BlockExecutionOutput { state, receipts, requests, .. } = state;
@@ -221,6 +249,10 @@ impl AppendableChain {
 
         let initial_execution_outcome =
             ExecutionOutcome::new(state, receipts.into(), block.number, vec![requests.into()]);
+
+        // stop the prefetch task.
+        #[cfg(feature = "prefetch")]
+        let _ = interrupt_tx.send(());
 
         // check state root if the block extends the canonical chain __and__ if state root
         // validation was requested.
@@ -284,7 +316,7 @@ impl AppendableChain {
         block_validation_kind: BlockValidationKind,
     ) -> Result<(), InsertBlockErrorKind>
     where
-        DB: Database + Clone,
+        DB: Database + Clone + 'static,
         E: BlockExecutorProvider,
     {
         let parent_block = self.chain.tip();

--- a/crates/blockchain-tree/src/shareable.rs
+++ b/crates/blockchain-tree/src/shareable.rs
@@ -37,7 +37,7 @@ impl<DB, E> ShareableBlockchainTree<DB, E> {
 
 impl<DB, E> BlockchainTreeEngine for ShareableBlockchainTree<DB, E>
 where
-    DB: Database + Clone,
+    DB: Database + Clone + 'static,
     E: BlockExecutorProvider,
 {
     fn buffer_block(&self, block: SealedBlockWithSenders) -> Result<(), InsertBlockError> {
@@ -108,7 +108,7 @@ where
 
 impl<DB, E> BlockchainTreeViewer for ShareableBlockchainTree<DB, E>
 where
-    DB: Database + Clone,
+    DB: Database + Clone + 'static,
     E: BlockExecutorProvider,
 {
     fn header_by_hash(&self, hash: BlockHash) -> Option<SealedHeader> {
@@ -171,7 +171,7 @@ where
 
 impl<DB, E> BlockchainTreePendingStateProvider for ShareableBlockchainTree<DB, E>
 where
-    DB: Database + Clone,
+    DB: Database + Clone + 'static,
     E: BlockExecutorProvider,
 {
     fn find_pending_state_provider(

--- a/crates/bsc/evm/Cargo.toml
+++ b/crates/bsc/evm/Cargo.toml
@@ -21,7 +21,6 @@ reth-prune-types.workspace = true
 reth-revm.workspace = true
 reth-provider.workspace = true
 reth-bsc-consensus.workspace = true
-reth-trie.workspace = true
 
 # Revm
 revm-primitives.workspace = true

--- a/crates/bsc/evm/Cargo.toml
+++ b/crates/bsc/evm/Cargo.toml
@@ -21,6 +21,7 @@ reth-prune-types.workspace = true
 reth-revm.workspace = true
 reth-provider.workspace = true
 reth-bsc-consensus.workspace = true
+reth-trie.workspace = true
 
 # Revm
 revm-primitives.workspace = true
@@ -33,6 +34,9 @@ parking_lot = "0.12.3"
 bitset = "0.1.2"
 lru = "0.12.3"
 blst = "0.3.12"
+
+# async
+tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
 reth-revm = { workspace = true, features = ["test-utils"] }

--- a/crates/bsc/evm/src/execute.rs
+++ b/crates/bsc/evm/src/execute.rs
@@ -28,11 +28,13 @@ use reth_revm::{
     db::states::bundle_state::BundleRetention,
     Evm, State,
 };
+use reth_trie::HashedPostState;
 use revm_primitives::{
     db::{Database, DatabaseCommit},
     BlockEnv, CfgEnvWithHandlerCfg, EVMError, EnvWithHandlerCfg, ResultAndState, TransactTo,
 };
 use std::{collections::HashMap, num::NonZeroUsize, sync::Arc, time::Instant};
+use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, warn};
 
 const SNAP_CACHE_NUM: usize = 2048;
@@ -80,17 +82,40 @@ where
     P: Clone,
     EvmConfig: ConfigureEvm,
 {
-    fn bsc_executor<DB>(&self, db: DB) -> BscBlockExecutor<EvmConfig, DB, P>
+    fn bsc_executor<DB>(
+        &self,
+        db: DB,
+        prefetch_tx: Option<UnboundedSender<HashedPostState>>,
+    ) -> BscBlockExecutor<EvmConfig, DB, P>
     where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
     {
-        BscBlockExecutor::new(
-            self.chain_spec.clone(),
-            self.evm_config.clone(),
-            self.parlia_config.clone(),
-            State::builder().with_database(db).with_bundle_update().without_state_clear().build(),
-            self.provider.clone(),
-        )
+        if let Some(tx) = prefetch_tx {
+            BscBlockExecutor::new_with_prefetch_tx(
+                self.chain_spec.clone(),
+                self.evm_config.clone(),
+                self.parlia_config.clone(),
+                State::builder()
+                    .with_database(db)
+                    .with_bundle_update()
+                    .without_state_clear()
+                    .build(),
+                self.provider.clone(),
+                tx,
+            )
+        } else {
+            BscBlockExecutor::new(
+                self.chain_spec.clone(),
+                self.evm_config.clone(),
+                self.parlia_config.clone(),
+                State::builder()
+                    .with_database(db)
+                    .with_bundle_update()
+                    .without_state_clear()
+                    .build(),
+                self.provider.clone(),
+            )
+        }
     }
 }
 
@@ -105,18 +130,22 @@ where
     type BatchExecutor<DB: Database<Error: Into<ProviderError> + std::fmt::Display>> =
         BscBatchExecutor<EvmConfig, DB, P>;
 
-    fn executor<DB>(&self, db: DB) -> Self::Executor<DB>
+    fn executor<DB>(
+        &self,
+        db: DB,
+        prefetch_tx: Option<UnboundedSender<HashedPostState>>,
+    ) -> Self::Executor<DB>
     where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
     {
-        self.bsc_executor(db)
+        self.bsc_executor(db, prefetch_tx)
     }
 
     fn batch_executor<DB>(&self, db: DB) -> Self::BatchExecutor<DB>
     where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
     {
-        let executor = self.bsc_executor(db);
+        let executor = self.bsc_executor(db, None);
         BscBatchExecutor {
             executor,
             batch_record: BlockBatchRecord::default(),
@@ -158,6 +187,7 @@ where
         &self,
         block: &BlockWithSenders,
         mut evm: Evm<'_, Ext, &mut State<DB>>,
+        tx: Option<UnboundedSender<HashedPostState>>,
     ) -> Result<(Vec<TransactionSigned>, Vec<Receipt>, u64), BlockExecutionError>
     where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
@@ -210,6 +240,13 @@ where
                 }
             })?;
 
+            if let Some(tx) = tx.as_ref() {
+                let post_state = HashedPostState::from_state(state.clone());
+                tx.send(post_state).unwrap_or_else(|err| {
+                    debug!(target: "evm_executor", ?err, "Failed to send post state to prefetch channel")
+                });
+            }
+
             evm.db_mut().commit(state);
 
             self.patch_mainnet_after_tx(transaction, evm.db_mut());
@@ -250,6 +287,8 @@ pub struct BscBlockExecutor<EvmConfig, DB, P> {
     pub(crate) provider: Arc<P>,
     /// Parlia consensus instance
     pub(crate) parlia: Arc<Parlia>,
+    /// Prefetch channel
+    prefetch_tx: Option<UnboundedSender<HashedPostState>>,
 }
 
 impl<EvmConfig, DB, P> BscBlockExecutor<EvmConfig, DB, P> {
@@ -268,6 +307,27 @@ impl<EvmConfig, DB, P> BscBlockExecutor<EvmConfig, DB, P> {
             state,
             provider: shared_provider,
             parlia,
+            prefetch_tx: None,
+        }
+    }
+
+    /// Creates a new BSC block executor with a prefetch channel.
+    pub fn new_with_prefetch_tx(
+        chain_spec: Arc<ChainSpec>,
+        evm_config: EvmConfig,
+        parlia_config: ParliaConfig,
+        state: State<DB>,
+        provider: P,
+        tx: UnboundedSender<HashedPostState>,
+    ) -> Self {
+        let parlia = Arc::new(Parlia::new(Arc::clone(&chain_spec), parlia_config));
+        let shared_provider = Arc::new(provider);
+        Self {
+            executor: BscEvmExecutor { chain_spec, evm_config },
+            state,
+            provider: shared_provider,
+            parlia,
+            prefetch_tx: Some(tx),
         }
     }
 
@@ -347,7 +407,7 @@ where
 
         let (mut system_txs, mut receipts, mut gas_used) = {
             let evm = self.executor.evm_config.evm_with_env(&mut self.state, env.clone());
-            self.executor.execute_pre_and_transactions(block, evm)
+            self.executor.execute_pre_and_transactions(block, evm, self.prefetch_tx.clone())
         }?;
 
         // 5. apply post execution changes

--- a/crates/bsc/evm/src/lib.rs
+++ b/crates/bsc/evm/src/lib.rs
@@ -2,6 +2,7 @@
 
 // TODO: doc
 #![allow(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 // The `bsc` feature must be enabled to use this crate.
 #![cfg(feature = "bsc")]

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -106,6 +106,10 @@ pub struct NodeCommand<Ext: clap::Args + fmt::Debug = NoArgs> {
     /// Additional cli arguments
     #[command(flatten, next_help_heading = "Extension")]
     pub ext: Ext,
+
+    /// Enable prefetch when executing block
+    #[arg(long, default_value_t = false)]
+    pub enable_prefetch: bool,
 }
 
 impl NodeCommand {
@@ -152,6 +156,7 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             dev,
             pruning,
             ext,
+            enable_prefetch,
         } = self;
 
         // set up node config
@@ -169,6 +174,7 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             db,
             dev,
             pruning,
+            enable_prefetch,
         };
 
         // Register the prometheus recorder before creating the database,

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -388,7 +388,7 @@ impl StorageInner {
             requests: block_execution_requests,
             gas_used,
             ..
-        } = executor.executor(&mut db).execute((&block, U256::ZERO, None).into())?;
+        } = executor.executor(&mut db, None).execute((&block, U256::ZERO, None).into())?;
         let execution_outcome = ExecutionOutcome::new(
             state,
             receipts.into(),

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -653,7 +653,8 @@ where
         self.validate_block(&block)?;
 
         let state_provider = self.state_provider(block.parent_hash).unwrap();
-        let executor = self.executor_provider.executor(StateProviderDatabase::new(&state_provider));
+        let executor =
+            self.executor_provider.executor(StateProviderDatabase::new(&state_provider), None);
 
         let block_number = block.number;
         let block_hash = block.hash();

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -20,6 +20,7 @@ reth-revm.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-prune-types.workspace = true
 reth-execution-types.workspace = true
+reth-trie.workspace = true
 
 # Ethereum
 revm-primitives.workspace = true
@@ -27,6 +28,12 @@ revm-primitives.workspace = true
 # Alloy
 alloy-eips.workspace = true
 alloy-sol-types.workspace = true
+
+# misc
+tracing.workspace = true
+
+# async
+tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
 reth-testing-utils.workspace = true

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -20,7 +20,6 @@ reth-revm.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-prune-types.workspace = true
 reth-execution-types.workspace = true
-reth-trie.workspace = true
 
 # Ethereum
 revm-primitives.workspace = true

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -28,10 +28,13 @@ use reth_revm::{
     state_change::{apply_blockhashes_update, post_block_balance_increments},
     Evm, State,
 };
+use reth_trie::HashedPostState;
 use revm_primitives::{
     db::{Database, DatabaseCommit},
     BlockEnv, CfgEnvWithHandlerCfg, EVMError, EnvWithHandlerCfg, ResultAndState,
 };
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::debug;
 
 #[cfg(feature = "std")]
 use std::{fmt::Display, sync::Arc, vec, vec::Vec};
@@ -65,15 +68,36 @@ impl<EvmConfig> EthExecutorProvider<EvmConfig>
 where
     EvmConfig: ConfigureEvm,
 {
-    fn eth_executor<DB>(&self, db: DB) -> EthBlockExecutor<EvmConfig, DB>
+    fn eth_executor<DB>(
+        &self,
+        db: DB,
+        prefetch_tx: Option<UnboundedSender<HashedPostState>>,
+    ) -> EthBlockExecutor<EvmConfig, DB>
     where
         DB: Database<Error: Into<ProviderError>>,
     {
-        EthBlockExecutor::new(
-            self.chain_spec.clone(),
-            self.evm_config.clone(),
-            State::builder().with_database(db).with_bundle_update().without_state_clear().build(),
-        )
+        if let Some(tx) = prefetch_tx {
+            EthBlockExecutor::new_with_prefetch_tx(
+                self.chain_spec.clone(),
+                self.evm_config.clone(),
+                State::builder()
+                    .with_database(db)
+                    .with_bundle_update()
+                    .without_state_clear()
+                    .build(),
+                tx,
+            )
+        } else {
+            EthBlockExecutor::new(
+                self.chain_spec.clone(),
+                self.evm_config.clone(),
+                State::builder()
+                    .with_database(db)
+                    .with_bundle_update()
+                    .without_state_clear()
+                    .build(),
+            )
+        }
     }
 }
 
@@ -87,18 +111,22 @@ where
     type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> =
         EthBatchExecutor<EvmConfig, DB>;
 
-    fn executor<DB>(&self, db: DB) -> Self::Executor<DB>
+    fn executor<DB>(
+        &self,
+        db: DB,
+        prefetch_tx: Option<UnboundedSender<HashedPostState>>,
+    ) -> Self::Executor<DB>
     where
         DB: Database<Error: Into<ProviderError> + Display>,
     {
-        self.eth_executor(db)
+        self.eth_executor(db, prefetch_tx)
     }
 
     fn batch_executor<DB>(&self, db: DB) -> Self::BatchExecutor<DB>
     where
         DB: Database<Error: Into<ProviderError> + Display>,
     {
-        let executor = self.eth_executor(db);
+        let executor = self.eth_executor(db, None);
         EthBatchExecutor {
             executor,
             batch_record: BlockBatchRecord::default(),
@@ -142,6 +170,7 @@ where
         &self,
         block: &BlockWithSenders,
         mut evm: Evm<'_, Ext, &mut State<DB>>,
+        tx: Option<UnboundedSender<HashedPostState>>,
     ) -> Result<EthExecuteOutput, BlockExecutionError>
     where
         DB: Database,
@@ -196,6 +225,14 @@ where
                     error: Box::new(new_err),
                 }
             })?;
+
+            if let Some(tx) = tx.as_ref() {
+                let post_state = HashedPostState::from_state(state.clone());
+                tx.send(post_state).unwrap_or_else(|err| {
+                    debug!(target: "evm_executor", ?err, "Failed to send post state to prefetch channel")
+                });
+            }
+
             evm.db_mut().commit(state);
 
             // append gas used
@@ -250,12 +287,24 @@ pub struct EthBlockExecutor<EvmConfig, DB> {
     executor: EthEvmExecutor<EvmConfig>,
     /// The state to use for execution
     state: State<DB>,
+    /// Prefetch channel
+    prefetch_tx: Option<UnboundedSender<HashedPostState>>,
 }
 
 impl<EvmConfig, DB> EthBlockExecutor<EvmConfig, DB> {
     /// Creates a new Ethereum block executor.
     pub const fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig, state: State<DB>) -> Self {
-        Self { executor: EthEvmExecutor { chain_spec, evm_config }, state }
+        Self { executor: EthEvmExecutor { chain_spec, evm_config }, state, prefetch_tx: None }
+    }
+
+    /// Creates a new Ethereum block executor with a prefetch channel.
+    pub const fn new_with_prefetch_tx(
+        chain_spec: Arc<ChainSpec>,
+        evm_config: EvmConfig,
+        state: State<DB>,
+        tx: UnboundedSender<HashedPostState>,
+    ) -> Self {
+        Self { executor: EthEvmExecutor { chain_spec, evm_config }, state, prefetch_tx: Some(tx) }
     }
 
     #[inline]
@@ -312,7 +361,7 @@ where
         let env = self.evm_env_for_block(&block.header, total_difficulty);
         let output = {
             let evm = self.executor.evm_config.evm_with_env(&mut self.state, env);
-            self.executor.execute_state_transitions(block, evm)
+            self.executor.execute_state_transitions(block, evm, self.prefetch_tx.clone())
         }?;
 
         // 3. apply post execution changes
@@ -552,7 +601,7 @@ mod tests {
 
         // attempt to execute a block without parent beacon block root, expect err
         let err = provider
-            .executor(StateProviderDatabase::new(&db))
+            .executor(StateProviderDatabase::new(&db), None)
             .execute(
                 (
                     &BlockWithSenders {
@@ -583,7 +632,7 @@ mod tests {
         // fix header, set a gas limit
         header.parent_beacon_block_root = Some(B256::with_last_byte(0x69));
 
-        let mut executor = provider.executor(StateProviderDatabase::new(&db));
+        let mut executor = provider.executor(StateProviderDatabase::new(&db), None);
 
         // Now execute a block with the fixed header, ensure that it does not fail
         executor
@@ -1322,7 +1371,7 @@ mod tests {
 
         let provider = executor_provider(chain_spec);
 
-        let executor = provider.executor(StateProviderDatabase::new(&db));
+        let executor = provider.executor(StateProviderDatabase::new(&db), None);
 
         let BlockExecutionOutput { receipts, requests, .. } = executor
             .execute(
@@ -1412,7 +1461,8 @@ mod tests {
         );
 
         // Create an executor from the state provider
-        let executor = executor_provider(chain_spec).executor(StateProviderDatabase::new(&db));
+        let executor =
+            executor_provider(chain_spec).executor(StateProviderDatabase::new(&db), None);
 
         // Execute the block and capture the result
         let exec_result = executor.execute(

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -19,12 +19,14 @@ revm-primitives.workspace = true
 reth-prune-types.workspace = true
 reth-storage-errors.workspace = true
 reth-execution-types.workspace = true
+reth-trie.workspace = true
 
 revm.workspace = true
 alloy-eips.workspace = true
 auto_impl.workspace = true
 futures-util.workspace = true
 parking_lot = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
 parking_lot.workspace = true

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -19,7 +19,6 @@ revm-primitives.workspace = true
 reth-prune-types.workspace = true
 reth-storage-errors.workspace = true
 reth-execution-types.workspace = true
-reth-trie.workspace = true
 
 revm.workspace = true
 alloy-eips.workspace = true

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -10,12 +10,11 @@ use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
-use revm_primitives::db::Database;
+use revm_primitives::{db::Database, EvmState};
+use tokio::sync::mpsc::UnboundedSender;
 
 // re-export Either
 pub use futures_util::future::Either;
-use reth_trie::HashedPostState;
-use tokio::sync::mpsc::UnboundedSender;
 
 impl<A, B> BlockExecutorProvider for Either<A, B>
 where
@@ -31,7 +30,7 @@ where
     fn executor<DB>(
         &self,
         db: DB,
-        prefetch_tx: Option<UnboundedSender<HashedPostState>>,
+        prefetch_tx: Option<UnboundedSender<EvmState>>,
     ) -> Self::Executor<DB>
     where
         DB: Database<Error: Into<ProviderError> + Display>,

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -5,7 +5,6 @@ use reth_primitives::{
     parlia::Snapshot, BlockNumber, BlockWithSenders, Header, Receipt, Request, B256, U256,
 };
 use reth_prune_types::PruneModes;
-use reth_trie::HashedPostState;
 use revm::db::BundleState;
 use revm_primitives::db::Database;
 use std::fmt::Display;
@@ -13,10 +12,10 @@ use tokio::sync::mpsc::UnboundedSender;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use std::collections::HashMap;
-
 pub use reth_execution_errors::{BlockExecutionError, BlockValidationError};
 pub use reth_storage_errors::provider::ProviderError;
+use revm_primitives::EvmState;
+use std::collections::HashMap;
 
 /// A general purpose executor trait that executes an input (e.g. block) and produces an output
 /// (e.g. state changes and receipts).
@@ -192,7 +191,7 @@ pub trait BlockExecutorProvider: Send + Sync + Clone + Unpin + 'static {
     fn executor<DB>(
         &self,
         db: DB,
-        prefetch_rx: Option<UnboundedSender<HashedPostState>>,
+        prefetch_rx: Option<UnboundedSender<EvmState>>,
     ) -> Self::Executor<DB>
     where
         DB: Database<Error: Into<ProviderError> + Display>;
@@ -223,7 +222,7 @@ mod tests {
         fn executor<DB>(
             &self,
             _db: DB,
-            _prefetch_tx: Option<UnboundedSender<HashedPostState>>,
+            _prefetch_tx: Option<UnboundedSender<EvmState>>,
         ) -> Self::Executor<DB>
         where
             DB: Database<Error: Into<ProviderError> + Display>,

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -7,8 +7,7 @@ use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
-use reth_trie::HashedPostState;
-use revm_primitives::db::Database;
+use revm_primitives::{db::Database, EvmState};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::execute::{
@@ -27,7 +26,7 @@ impl BlockExecutorProvider for NoopBlockExecutorProvider {
 
     type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> = Self;
 
-    fn executor<DB>(&self, _: DB, _: Option<UnboundedSender<HashedPostState>>) -> Self::Executor<DB>
+    fn executor<DB>(&self, _: DB, _: Option<UnboundedSender<EvmState>>) -> Self::Executor<DB>
     where
         DB: Database<Error: Into<ProviderError> + Display>,
     {

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -7,7 +7,9 @@ use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
+use reth_trie::HashedPostState;
 use revm_primitives::db::Database;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::execute::{
     BatchExecutor, BlockExecutionInput, BlockExecutionOutput, BlockExecutorProvider, Executor,
@@ -25,7 +27,7 @@ impl BlockExecutorProvider for NoopBlockExecutorProvider {
 
     type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> = Self;
 
-    fn executor<DB>(&self, _: DB) -> Self::Executor<DB>
+    fn executor<DB>(&self, _: DB, _: Option<UnboundedSender<HashedPostState>>) -> Self::Executor<DB>
     where
         DB: Database<Error: Into<ProviderError> + Display>,
     {

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -9,8 +9,7 @@ use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
-use reth_trie::HashedPostState;
-use revm_primitives::db::Database;
+use revm_primitives::{db::Database, EvmState};
 use std::{fmt::Display, sync::Arc};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -32,7 +31,7 @@ impl BlockExecutorProvider for MockExecutorProvider {
 
     type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> = Self;
 
-    fn executor<DB>(&self, _: DB, _: Option<UnboundedSender<HashedPostState>>) -> Self::Executor<DB>
+    fn executor<DB>(&self, _: DB, _: Option<UnboundedSender<EvmState>>) -> Self::Executor<DB>
     where
         DB: Database<Error: Into<ProviderError> + Display>,
     {

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -9,8 +9,10 @@ use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
+use reth_trie::HashedPostState;
 use revm_primitives::db::Database;
 use std::{fmt::Display, sync::Arc};
+use tokio::sync::mpsc::UnboundedSender;
 
 /// A [`BlockExecutorProvider`] that returns mocked execution results.
 #[derive(Clone, Debug, Default)]
@@ -30,7 +32,7 @@ impl BlockExecutorProvider for MockExecutorProvider {
 
     type BatchExecutor<DB: Database<Error: Into<ProviderError> + Display>> = Self;
 
-    fn executor<DB>(&self, _: DB) -> Self::Executor<DB>
+    fn executor<DB>(&self, _: DB, _: Option<UnboundedSender<HashedPostState>>) -> Self::Executor<DB>
     where
         DB: Database<Error: Into<ProviderError> + Display>,
     {

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -55,9 +55,12 @@ where
             .ok_or_else(|| ProviderError::HeaderNotFound(block_number.into()))?;
 
         // Configure the executor to use the previous block's state.
-        let executor = self.executor.executor(StateProviderDatabase::new(
-            self.provider.history_by_block_number(block_number.saturating_sub(1))?,
-        ));
+        let executor = self.executor.executor(
+            StateProviderDatabase::new(
+                self.provider.history_by_block_number(block_number.saturating_sub(1))?,
+            ),
+            None,
+        );
 
         trace!(target: "exex::backfill", number = block_number, txs = block_with_senders.block.body.len(), "Executing block");
 

--- a/crates/exex/exex/src/backfill/mod.rs
+++ b/crates/exex/exex/src/backfill/mod.rs
@@ -283,10 +283,13 @@ mod tests {
 
         // Execute the block to produce a block execution output
         let mut block_execution_output = EthExecutorProvider::ethereum(chain_spec)
-            .executor(StateProviderDatabase::new(LatestStateProviderRef::new(
-                provider.tx_ref(),
-                provider.static_file_provider().clone(),
-            )))
+            .executor(
+                StateProviderDatabase::new(LatestStateProviderRef::new(
+                    provider.tx_ref(),
+                    provider.static_file_provider().clone(),
+                )),
+                None,
+            )
             .execute(BlockExecutionInput {
                 block,
                 total_difficulty: U256::ZERO,

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -640,12 +640,18 @@ where
             consensus.clone(),
             components.block_executor().clone(),
         );
-        let tree = BlockchainTree::new(tree_externals, *self.tree_config(), self.prune_modes())?
-            .with_sync_metrics_tx(self.sync_metrics_tx())
-            // Note: This is required because we need to ensure that both the components and the
-            // tree are using the same channel for canon state notifications. This will be removed
-            // once the Blockchain provider no longer depends on an instance of the tree
-            .with_canon_state_notification_sender(self.canon_state_notification_sender());
+        let mut tree =
+            BlockchainTree::new(tree_externals, *self.tree_config(), self.prune_modes())?
+                .with_sync_metrics_tx(self.sync_metrics_tx())
+                // Note: This is required because we need to ensure that both the components and the
+                // tree are using the same channel for canon state notifications. This will be
+                // removed once the Blockchain provider no longer depends on an
+                // instance of the tree
+                .with_canon_state_notification_sender(self.canon_state_notification_sender());
+
+        if self.node_config().enable_prefetch {
+            tree = tree.enable_prefetch();
+        }
 
         let blockchain_tree = Arc::new(ShareableBlockchainTree::new(tree));
 

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -145,6 +145,9 @@ pub struct NodeConfig {
 
     /// All pruning related arguments
     pub pruning: PruningArgs,
+
+    /// Enable prefetch when executing blocks.
+    pub enable_prefetch: bool,
 }
 
 impl NodeConfig {
@@ -436,6 +439,7 @@ impl Default for NodeConfig {
             dev: DevArgs::default(),
             pruning: PruningArgs::default(),
             datadir: DatadirArgs::default(),
+            enable_prefetch: false,
         }
     }
 }

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -21,7 +21,6 @@ reth-execution-errors.workspace = true
 reth-execution-types.workspace = true
 reth-prune-types.workspace = true
 reth-consensus-common.workspace = true
-reth-trie.workspace = true
 
 # Optimism
 reth-optimism-consensus.workspace = true

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -21,6 +21,7 @@ reth-execution-errors.workspace = true
 reth-execution-types.workspace = true
 reth-prune-types.workspace = true
 reth-consensus-common.workspace = true
+reth-trie.workspace = true
 
 # Optimism
 reth-optimism-consensus.workspace = true
@@ -32,6 +33,9 @@ revm-primitives.workspace = true
 # misc
 thiserror.workspace = true
 tracing.workspace = true
+
+# async
+tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
 reth-revm = { workspace = true, features = ["test-utils"] }

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -22,13 +22,15 @@ use reth_revm::{
     state_change::post_block_balance_increments,
     Evm, State,
 };
+use reth_trie::HashedPostState;
 use revm::db::states::StorageSlot;
 use revm_primitives::{
     db::{Database, DatabaseCommit},
     BlockEnv, CfgEnvWithHandlerCfg, EVMError, EnvWithHandlerCfg, ResultAndState,
 };
 use std::{collections::HashMap, str::FromStr, sync::Arc};
-use tracing::trace;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::{debug, trace};
 
 /// Provides executors to execute regular ethereum blocks
 #[derive(Debug, Clone)]
@@ -55,15 +57,36 @@ impl<EvmConfig> OpExecutorProvider<EvmConfig>
 where
     EvmConfig: ConfigureEvm,
 {
-    fn op_executor<DB>(&self, db: DB) -> OpBlockExecutor<EvmConfig, DB>
+    fn op_executor<DB>(
+        &self,
+        db: DB,
+        prefetch_tx: Option<UnboundedSender<HashedPostState>>,
+    ) -> OpBlockExecutor<EvmConfig, DB>
     where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
     {
-        OpBlockExecutor::new(
-            self.chain_spec.clone(),
-            self.evm_config.clone(),
-            State::builder().with_database(db).with_bundle_update().without_state_clear().build(),
-        )
+        if let Some(tx) = prefetch_tx {
+            OpBlockExecutor::new_with_prefetch_tx(
+                self.chain_spec.clone(),
+                self.evm_config.clone(),
+                State::builder()
+                    .with_database(db)
+                    .with_bundle_update()
+                    .without_state_clear()
+                    .build(),
+                tx,
+            )
+        } else {
+            OpBlockExecutor::new(
+                self.chain_spec.clone(),
+                self.evm_config.clone(),
+                State::builder()
+                    .with_database(db)
+                    .with_bundle_update()
+                    .without_state_clear()
+                    .build(),
+            )
+        }
     }
 }
 
@@ -76,18 +99,22 @@ where
 
     type BatchExecutor<DB: Database<Error: Into<ProviderError> + std::fmt::Display>> =
         OpBatchExecutor<EvmConfig, DB>;
-    fn executor<DB>(&self, db: DB) -> Self::Executor<DB>
+    fn executor<DB>(
+        &self,
+        db: DB,
+        prefetch_tx: Option<UnboundedSender<HashedPostState>>,
+    ) -> Self::Executor<DB>
     where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
     {
-        self.op_executor(db)
+        self.op_executor(db, prefetch_tx)
     }
 
     fn batch_executor<DB>(&self, db: DB) -> Self::BatchExecutor<DB>
     where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
     {
-        let executor = self.op_executor(db);
+        let executor = self.op_executor(db, None);
         OpBatchExecutor {
             executor,
             batch_record: BlockBatchRecord::default(),
@@ -120,6 +147,7 @@ where
         &self,
         block: &BlockWithSenders,
         mut evm: Evm<'_, Ext, &mut State<DB>>,
+        tx: Option<UnboundedSender<HashedPostState>>,
     ) -> Result<(Vec<Receipt>, u64), BlockExecutionError>
     where
         DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
@@ -204,6 +232,13 @@ where
                 "Executed transaction"
             );
 
+            if let Some(tx) = tx.as_ref() {
+                let post_state = HashedPostState::from_state(state.clone());
+                tx.send(post_state).unwrap_or_else(|err| {
+                    debug!(target: "evm_executor", ?err, "Failed to send post state to prefetch channel")
+                });
+            }
+
             evm.db_mut().commit(state);
 
             // append gas used
@@ -244,12 +279,24 @@ pub struct OpBlockExecutor<EvmConfig, DB> {
     executor: OpEvmExecutor<EvmConfig>,
     /// The state to use for execution
     state: State<DB>,
+    /// Prefetch channel
+    prefetch_tx: Option<UnboundedSender<HashedPostState>>,
 }
 
 impl<EvmConfig, DB> OpBlockExecutor<EvmConfig, DB> {
-    /// Creates a new Ethereum block executor.
+    /// Creates a new Optimism block executor.
     pub const fn new(chain_spec: Arc<ChainSpec>, evm_config: EvmConfig, state: State<DB>) -> Self {
-        Self { executor: OpEvmExecutor { chain_spec, evm_config }, state }
+        Self { executor: OpEvmExecutor { chain_spec, evm_config }, state, prefetch_tx: None }
+    }
+
+    /// Creates a new Optimism block executor with a prefetch channel.
+    pub const fn new_with_prefetch_tx(
+        chain_spec: Arc<ChainSpec>,
+        evm_config: EvmConfig,
+        state: State<DB>,
+        tx: UnboundedSender<HashedPostState>,
+    ) -> Self {
+        Self { executor: OpEvmExecutor { chain_spec, evm_config }, state, prefetch_tx: Some(tx) }
     }
 
     #[inline]
@@ -304,7 +351,7 @@ where
 
         let (receipts, gas_used) = {
             let evm = self.executor.evm_config.evm_with_env(&mut self.state, env);
-            self.executor.execute_pre_and_transactions(block, evm)
+            self.executor.execute_pre_and_transactions(block, evm, self.prefetch_tx.clone())
         }?;
 
         // 3. apply post execution changes

--- a/crates/trie/prefetch/Cargo.toml
+++ b/crates/trie/prefetch/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "reth-trie-prefetch"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Prefetch trie storages when executing block"
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-primitives.workspace = true
+reth-db.workspace = true
+reth-trie.workspace = true
+reth-provider.workspace = true
+reth-trie-parallel.workspace = true
+reth-tasks.workspace = true
+reth-execution-errors.workspace = true
+
+# alloy
+alloy-rlp.workspace = true
+
+# tracing
+tracing.workspace = true
+
+# misc
+thiserror.workspace = true
+derive_more.workspace = true
+rayon.workspace = true
+
+# async
+tokio = { workspace = true, default-features = false, features = ["sync", "rt", "macros"] }
+
+# `metrics` feature
+reth-metrics = { workspace = true, optional = true }
+metrics = { workspace = true, optional = true }
+
+[dev-dependencies]
+# reth
+reth-primitives = { workspace = true, features = ["test-utils", "arbitrary"] }
+reth-provider = { workspace = true, features = ["test-utils"] }
+reth-trie = { workspace = true, features = ["test-utils"] }
+
+# misc
+rand.workspace = true
+criterion = { workspace = true, features = ["async_tokio"] }
+proptest.workspace = true
+
+[features]
+default = ["metrics"]
+metrics = ["reth-metrics", "dep:metrics", "reth-trie/metrics"]

--- a/crates/trie/prefetch/src/lib.rs
+++ b/crates/trie/prefetch/src/lib.rs
@@ -1,0 +1,14 @@
+//! Implementation of exotic trie prefetch approaches.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+pub use reth_trie_parallel::StorageRootTargets;
+
+/// Implementation of trie prefetch.
+mod prefetch;
+pub use prefetch::TriePrefetch;

--- a/crates/trie/prefetch/src/prefetch.rs
+++ b/crates/trie/prefetch/src/prefetch.rs
@@ -1,0 +1,305 @@
+use rayon::prelude::*;
+use reth_db::database::Database;
+use reth_execution_errors::StorageRootError;
+use reth_primitives::B256;
+use reth_provider::{providers::ConsistentDbView, ProviderError, ProviderFactory};
+use reth_trie::{
+    hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
+    metrics::TrieRootMetrics,
+    node_iter::{TrieElement, TrieNodeIter},
+    stats::TrieTracker,
+    trie_cursor::TrieCursorFactory,
+    walker::TrieWalker,
+    HashedPostState, HashedStorage, StorageRoot,
+};
+use reth_trie_parallel::{parallel_root::ParallelStateRootError, StorageRootTargets};
+use std::{collections::HashMap, sync::Arc};
+use thiserror::Error;
+use tokio::sync::{mpsc::UnboundedReceiver, oneshot::Receiver, watch};
+use tracing::{debug, trace};
+
+/// Prefetch trie storage when executing transactions.
+#[derive(Debug, Clone)]
+pub struct TriePrefetch {
+    /// Cached accounts.
+    cached_accounts: HashMap<B256, bool>,
+    /// Cached storages.
+    cached_storages: HashMap<B256, HashMap<B256, bool>>,
+    /// State trie metrics.
+    #[cfg(feature = "metrics")]
+    metrics: TrieRootMetrics,
+}
+
+impl Default for TriePrefetch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TriePrefetch {
+    /// Create new `TriePrefetch` instance.
+    pub fn new() -> Self {
+        Self {
+            cached_accounts: HashMap::new(),
+            cached_storages: HashMap::new(),
+            #[cfg(feature = "metrics")]
+            metrics: TrieRootMetrics::default(),
+        }
+    }
+
+    /// Run the prefetching task.
+    pub async fn run<DB>(
+        &mut self,
+        consistent_view: Arc<ConsistentDbView<DB, ProviderFactory<DB>>>,
+        mut prefetch_rx: UnboundedReceiver<HashedPostState>,
+        mut interrupt_rx: Receiver<()>,
+    ) where
+        DB: Database + 'static,
+    {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let mut count = 0u64;
+        loop {
+            tokio::select! {
+                hashed_state = prefetch_rx.recv() => {
+                    if let Some(hashed_state) = hashed_state {
+                        count += 1;
+
+                        let consistent_view = Arc::clone(&consistent_view);
+                        let hashed_state = self.deduplicate_and_update_cached(&hashed_state);
+
+                        let self_clone = Arc::new(self.clone());
+                        let mut shutdown_rx = shutdown_rx.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = self_clone.prefetch_once::<DB>(consistent_view, hashed_state, &mut shutdown_rx).await {
+                                debug!(target: "trie::trie_prefetch", ?e, "Error while prefetching trie storage");
+                            };
+                        });
+                    }
+                }
+                _ = &mut interrupt_rx => {
+                    debug!(target: "trie::trie_prefetch", "Interrupted trie prefetch task. Processed {:?}, left {:?}", count, prefetch_rx.len());
+                    let _ = shutdown_tx.send(true);
+                    return
+                }
+            }
+        }
+    }
+
+    /// Deduplicate `hashed_state` based on `cached` and update `cached`.
+    fn deduplicate_and_update_cached(&mut self, hashed_state: &HashedPostState) -> HashedPostState {
+        let mut new_hashed_state = HashedPostState::default();
+
+        // deduplicate accounts if their keys are not present in storages
+        for (address, account) in &hashed_state.accounts {
+            if !hashed_state.storages.contains_key(address) &&
+                !self.cached_accounts.contains_key(address)
+            {
+                self.cached_accounts.insert(*address, true);
+                new_hashed_state.accounts.insert(*address, *account);
+            }
+        }
+
+        // deduplicate storages
+        for (address, storage) in &hashed_state.storages {
+            let cached_entry = self.cached_storages.entry(*address).or_default();
+
+            // Collect the keys to be added to `new_storage` after filtering
+            let keys_to_add: Vec<_> = storage
+                .storage
+                .iter()
+                .filter(|(slot, _)| !cached_entry.contains_key(*slot))
+                .map(|(slot, _)| *slot)
+                .collect();
+
+            // Iterate over `keys_to_add` to update `cached_entry` and `new_storage`
+            let new_storage: HashMap<_, _> = keys_to_add
+                .into_iter()
+                .map(|slot| {
+                    cached_entry.insert(slot, true);
+                    (slot, *storage.storage.get(&slot).unwrap())
+                })
+                .collect();
+
+            if !new_storage.is_empty() {
+                new_hashed_state
+                    .storages
+                    .insert(*address, HashedStorage::from_iter(false, new_storage.into_iter()));
+
+                if let Some(account) = hashed_state.accounts.get(address) {
+                    new_hashed_state.accounts.insert(*address, *account);
+                }
+            }
+        }
+
+        new_hashed_state
+    }
+
+    /// Prefetch trie storage for the given hashed state.
+    pub async fn prefetch_once<DB>(
+        self: Arc<Self>,
+        consistent_view: Arc<ConsistentDbView<DB, ProviderFactory<DB>>>,
+        hashed_state: HashedPostState,
+        shutdown_rx: &mut watch::Receiver<bool>,
+    ) -> Result<(), TriePrefetchError>
+    where
+        DB: Database,
+    {
+        let mut tracker = TrieTracker::default();
+
+        let prefix_sets = hashed_state.construct_prefix_sets().freeze();
+        let storage_root_targets = StorageRootTargets::new(
+            hashed_state.accounts.keys().copied(),
+            prefix_sets.storage_prefix_sets,
+        );
+        let hashed_state_sorted = hashed_state.into_sorted();
+
+        trace!(target: "trie::trie_prefetch", "start prefetching trie storages");
+        let mut storage_roots = storage_root_targets
+            .into_par_iter()
+            .map(|(hashed_address, prefix_set)| {
+                if *shutdown_rx.borrow() {
+                    return Ok((B256::ZERO, 0)); // return early if shutdown
+                }
+
+                let provider_ro = consistent_view.provider_ro()?;
+
+                let storage_root_result = StorageRoot::new_hashed(
+                    provider_ro.tx_ref(),
+                    HashedPostStateCursorFactory::new(provider_ro.tx_ref(), &hashed_state_sorted),
+                    hashed_address,
+                    #[cfg(feature = "metrics")]
+                    self.metrics.clone(),
+                )
+                .with_prefix_set(prefix_set)
+                .prefetch();
+
+                Ok((hashed_address, storage_root_result?))
+            })
+            .collect::<Result<HashMap<_, _>, ParallelStateRootError>>()?;
+
+        if *shutdown_rx.borrow() {
+            return Ok(()); // return early if shutdown
+        }
+
+        trace!(target: "trie::trie_prefetch", "prefetching account tries");
+        let provider_ro = consistent_view.provider_ro()?;
+        let hashed_cursor_factory =
+            HashedPostStateCursorFactory::new(provider_ro.tx_ref(), &hashed_state_sorted);
+        let trie_cursor_factory = provider_ro.tx_ref();
+
+        let walker = TrieWalker::new(
+            trie_cursor_factory.account_trie_cursor().map_err(ProviderError::Database)?,
+            prefix_sets.account_prefix_set,
+        )
+        .with_deletions_retained(false);
+        let mut account_node_iter = TrieNodeIter::new(
+            walker,
+            hashed_cursor_factory.hashed_account_cursor().map_err(ProviderError::Database)?,
+        );
+
+        while let Some(node) = account_node_iter.try_next().map_err(ProviderError::Database)? {
+            if *shutdown_rx.borrow() {
+                return Ok(()); // return early if shutdown
+            }
+
+            match node {
+                TrieElement::Branch(_) => {
+                    tracker.inc_branch();
+                }
+                TrieElement::Leaf(hashed_address, _) => {
+                    match storage_roots.remove(&hashed_address) {
+                        Some(result) => result,
+                        // Since we do not store all intermediate nodes in the database, there might
+                        // be a possibility of re-adding a non-modified leaf to the hash builder.
+                        None => StorageRoot::new_hashed(
+                            trie_cursor_factory,
+                            hashed_cursor_factory.clone(),
+                            hashed_address,
+                            #[cfg(feature = "metrics")]
+                            self.metrics.clone(),
+                        )
+                        .prefetch()
+                        .ok()
+                        .unwrap_or_default(),
+                    };
+                    tracker.inc_leaf();
+                }
+            }
+        }
+
+        let stats = tracker.finish();
+
+        #[cfg(feature = "metrics")]
+        self.metrics.record(stats);
+
+        trace!(
+            target: "trie::trie_prefetch",
+            duration = ?stats.duration(),
+            branches_added = stats.branches_added(),
+            leaves_added = stats.leaves_added(),
+            "prefetched account trie"
+        );
+
+        Ok(())
+    }
+}
+
+/// Error during prefetching trie storage.
+#[derive(Error, Debug)]
+pub enum TriePrefetchError {
+    /// Error while calculating storage root.
+    #[error(transparent)]
+    StorageRoot(#[from] StorageRootError),
+    /// Error while calculating parallel storage root.
+    #[error(transparent)]
+    ParallelStateRoot(#[from] ParallelStateRootError),
+    /// Provider error.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+}
+
+impl From<TriePrefetchError> for ProviderError {
+    fn from(error: TriePrefetchError) -> Self {
+        match error {
+            TriePrefetchError::Provider(error) => error,
+            TriePrefetchError::StorageRoot(StorageRootError::DB(error)) => Self::Database(error),
+            TriePrefetchError::ParallelStateRoot(error) => error.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::time;
+
+    #[tokio::test]
+    async fn test_channel() {
+        let (prefetch_tx, mut prefetch_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (interrupt_tx, mut interrupt_rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = prefetch_rx.recv() => {
+                        println!("got message");
+                        time::sleep(time::Duration::from_secs(3)).await;
+                    }
+                    _ = &mut interrupt_rx => {
+                        println!("left items in channel: {}" ,prefetch_rx.len());
+                        break;
+                    }
+                }
+            }
+        });
+
+        for _ in 0..10 {
+            prefetch_tx.send(()).unwrap();
+        }
+
+        time::sleep(time::Duration::from_secs(3)).await;
+
+        interrupt_tx.send(()).unwrap();
+
+        time::sleep(time::Duration::from_secs(10)).await;
+    }
+}

--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -16,7 +16,7 @@ use reth_db_api::{
 use reth_execution_errors::StateRootError;
 use reth_primitives::{keccak256, Account, Address, BlockNumber, B256, U256};
 use reth_trie_common::AccountProof;
-use revm::db::BundleAccount;
+use revm::{db::BundleAccount, primitives::AccountStatus};
 use std::{
     collections::{hash_map, HashMap, HashSet},
     ops::RangeInclusive,
@@ -60,6 +60,26 @@ impl HashedPostState {
             storages.insert(address, storage);
         }
         Self { accounts, storages }
+    }
+
+    /// Initialize [`HashedPostState`] from evm state.
+    pub fn from_state(
+        changes: HashMap<Address, reth_primitives::revm_primitives::Account>,
+    ) -> Self {
+        let mut this = Self::default();
+        for (address, account) in changes {
+            let hashed_address = keccak256(address);
+            this.accounts.insert(hashed_address, Some(account.info.clone().into()));
+
+            let hashed_storage = HashedStorage::from_iter(
+                account.status == AccountStatus::SelfDestructed,
+                account.storage.iter().map(|(key, value)| {
+                    (keccak256(B256::new(key.to_be_bytes())), value.present_value)
+                }),
+            );
+            this.storages.insert(hashed_address, hashed_storage);
+        }
+        this
     }
 
     /// Initialize [`HashedPostState`] from revert range.


### PR DESCRIPTION
### Description

This pull request enhances merkleization efficiency by prefetching trie nodes from the database during execution.

### Rationale

**This pull request can enhance merkleization efficiency by approximately 56% for the BSC network.**

### Example

We separately tracked the time taken for inserting blocks, executing blocks, and calculating the state root during live sync. We will compare these metrics to gain insights into their performance.

**BSC Test Result - Live sync 14K blocks, from 41550000 to 41564139.** 

- Statistical Average
<img width="607" alt="image" src="https://github.com/user-attachments/assets/ba9ce0a1-4a5b-4399-88b7-53f38e8b4fe1">

- Scatter Plot for Execution Time
![image](https://github.com/user-attachments/assets/c3197285-f383-4d98-85d4-604308827602)

- Scatter Plot for State Root Calculation Time
![image](https://github.com/user-attachments/assets/84f5d704-43e4-4f99-957e-2789b7b903da)

- Scatter Plot for Total Time
![image](https://github.com/user-attachments/assets/249b7f59-336f-4334-9088-22c90e060ad2)

The Prefetch feature boosts state root calculation efficiency during BSC live sync without compromising block execution efficiency. This leads to a 56% decrease in state root calculation time and a 29% reduction in total block insertion time.

**opBNB Test Result - Live sync 14K blocks, from 33180000 to 33194139.** 

- Statistical Average
<img width="606" alt="image" src="https://github.com/user-attachments/assets/9bdebd11-5dfb-4240-9e8c-d22814492c1a">

- Scatter Plot for Execution Time
![image](https://github.com/user-attachments/assets/3986fcdd-4046-438e-aa0e-d6d86fd99099)

- Scatter Plot for State Root Calculation Time
![image](https://github.com/user-attachments/assets/7d9206a3-95de-4b66-9e23-f700c140644e)

- Scatter Plot for Total Time
![image](https://github.com/user-attachments/assets/f3f85b9c-8a88-4dd5-8e2d-2029183a8a77)

In the case of opBNB, the execution time, state root calculation time, and total time for block insertion are all relatively small. Prefetching optimization doesn't show clear benefits for opBNB. This could be due to the small world state tree of opBNB. When opBNB runs on a machine with 128GB of memory, most trie nodes are already in memory, making prefetch optimization ineffective.

### Changes

Notable changes: 
* Add trie prefetch when executing blocks

### Potential Impacts
* NA
