### PR TITLE
fix: add check of plato hardfork in `verify_vote_attestation`

### DIFF
--- a/crates/bsc/evm/src/pre_execution.rs
+++ b/crates/bsc/evm/src/pre_execution.rs
@@ -77,6 +77,10 @@ where
         header: &Header,
         parent: &Header,
     ) -> Result<(), BlockExecutionError> {
+        if !self.parlia().chain_spec().is_plato_active_at_block(header.number) {
+            return Ok(());
+        }
+
         let attestation =
             self.parlia().get_vote_attestation_from_header(header).map_err(|err| {
                 BscBlockExecutionError::ParliaConsensusInnerError { error: err.into() }


### PR DESCRIPTION
### Description

This pr is to fix an issue that `verify_vote_attestation` should not enable before plato

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
