### PR TITLE
fix: add sidecars to db when doing `insert_block`

### DIFF
--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -61,6 +61,7 @@ pub(crate) enum Action {
     InsertTransactions,
     InsertTransactionHashNumbers,
     InsertBlockWithdrawals,
+    InsertBlockSidecars,
     InsertBlockRequests,
     InsertBlockBodyIndices,
     InsertTransactionBlocks,
@@ -106,6 +107,8 @@ struct DatabaseProviderMetrics {
     insert_tx_hash_numbers: Histogram,
     /// Duration of insert block withdrawals
     insert_block_withdrawals: Histogram,
+    /// Duration of insert block sidecars
+    insert_block_sidecars: Histogram,
     /// Duration of insert block requests
     insert_block_requests: Histogram,
     /// Duration of insert block body indices
@@ -139,6 +142,7 @@ impl DatabaseProviderMetrics {
             Action::InsertTransactions => self.insert_transactions.record(duration),
             Action::InsertTransactionHashNumbers => self.insert_tx_hash_numbers.record(duration),
             Action::InsertBlockWithdrawals => self.insert_block_withdrawals.record(duration),
+            Action::InsertBlockSidecars => self.insert_block_sidecars.record(duration),
             Action::InsertBlockRequests => self.insert_block_requests.record(duration),
             Action::InsertBlockBodyIndices => self.insert_block_body_indices.record(duration),
             Action::InsertTransactionBlocks => self.insert_tx_blocks.record(duration),

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2796,6 +2796,10 @@ impl<TX: DbTxMut + DbTx> BlockWriter for DatabaseProvider<TX> {
             }
         }
 
+        let sidecars = block.block.sidecars.unwrap_or_default();
+        self.tx.put::<tables::Sidecars>(block_number, sidecars)?;
+        durations_recorder.record_relative(metrics::Action::InsertBlockSidecars);
+
         let block_indices = StoredBlockBodyIndices { first_tx_num, tx_count };
         self.tx.put::<tables::BlockBodyIndices>(block_number, block_indices.clone())?;
         durations_recorder.record_relative(metrics::Action::InsertBlockBodyIndices);


### PR DESCRIPTION
### Description

This pr is to fix an issue that sidecars are not added to db when doing live sync

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
