### PR TITLE
[draft] feat: add more cache to stage sync & live sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6774,6 +6774,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick_cache"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3327c42419cab9678a66fb21f4c6222b6df3ad9114e56816b0defcd7649e0c"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.14.5",
+ "parking_lot 0.12.3",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7348,9 +7360,12 @@ dependencies = [
  "alloy-genesis",
  "aquamarine",
  "assert_matches",
+ "lazy_static",
  "linked_hash_set",
+ "lru",
  "metrics",
  "parking_lot 0.12.3",
+ "quick_cache",
  "reth-blockchain-tree-api",
  "reth-chainspec",
  "reth-consensus",
@@ -7363,6 +7378,7 @@ dependencies = [
  "reth-metrics",
  "reth-network",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
  "reth-revm",
@@ -9491,7 +9507,10 @@ dependencies = [
  "criterion",
  "futures-util",
  "itertools 0.13.0",
+ "lazy_static",
+ "lru",
  "num-traits",
+ "parking_lot 0.12.3",
  "paste",
  "pprof",
  "rand 0.8.5",

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -28,6 +28,10 @@ reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-parallel = { workspace = true, features = ["parallel"] }
 reth-network.workspace = true
 reth-consensus.workspace = true
+reth-primitives-traits.workspace = true
+
+# cache
+quick_cache = "0.6.1"
 
 # common
 parking_lot.workspace = true
@@ -41,6 +45,8 @@ metrics.workspace = true
 # misc
 aquamarine.workspace = true
 linked_hash_set.workspace = true
+lru = "0.12.3"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 reth-chainspec.workspace = true

--- a/crates/blockchain-tree/src/execution_cache.rs
+++ b/crates/blockchain-tree/src/execution_cache.rs
@@ -1,0 +1,235 @@
+use std::{collections::HashMap, num::NonZeroUsize};
+
+use lazy_static::lazy_static;
+use lru::LruCache;
+use metrics::Counter;
+use parking_lot::RwLock;
+use tracing::debug;
+
+use quick_cache::sync::Cache;
+use reth_metrics::Metrics;
+use reth_primitives::{Account, Address, BlockNumber, Bytecode, StorageKey, StorageValue, B256};
+use reth_provider::{
+    AccountReader, BlockHashReader, ExecutionDataProvider, StateProofProvider, StateProvider,
+    StateRootProvider,
+};
+use reth_revm::db::BundleState;
+use reth_storage_errors::provider::ProviderResult;
+use reth_trie::{updates::TrieUpdates, AccountProof};
+/// The size of cache, counted by the number of accounts.
+const CACHE_SIZE: usize = 10240;
+
+lazy_static! {
+    /// Account cache
+    static ref ACCOUNT_CACHE: Cache<Address, Account> = Cache::new(CACHE_SIZE);
+
+    /// Storage cache
+    static ref STORAGE_CACHE: Cache<Address, HashMap<StorageKey, StorageValue>> = Cache::new(CACHE_SIZE);
+}
+
+/// Metrics for cache.
+#[derive(Metrics)]
+#[metrics(scope = "blockchain_tree.cache")]
+pub(crate) struct CacheMetrics {
+    /// Total account access count
+    pub(crate) account_access_total: Counter,
+    /// Total account access cache hit count
+    pub(crate) account_cache_hit_total: Counter,
+    /// Total storage access count
+    pub(crate) storage_access_total: Counter,
+    /// Total storage access cache hit count
+    pub(crate) storage_cache_hit_total: Counter,
+}
+
+pub(crate) fn apply_bundle_state_to_cache(bundle: BundleState) {
+    let change_set = bundle.into_plain_state(reth_provider::OriginalValuesKnown::Yes);
+
+    for (address, account_info) in change_set.accounts.iter() {
+        match account_info {
+            None => {
+                ACCOUNT_CACHE.remove(address);
+                STORAGE_CACHE.remove(address);
+            }
+            Some(acc) => {
+                ACCOUNT_CACHE.insert(
+                    *address,
+                    Account {
+                        nonce: acc.nonce,
+                        balance: acc.balance,
+                        bytecode_hash: Some(acc.code_hash),
+                    },
+                );
+            }
+        }
+    }
+
+    for storage in change_set.storage.iter() {
+        if storage.wipe_storage {
+            STORAGE_CACHE.remove(&storage.address);
+        } else {
+            let mut map = HashMap::new();
+            for (k, v) in storage.storage.clone() {
+                map.insert(k.into(), v);
+            }
+            STORAGE_CACHE.insert(storage.address, map);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CachedBundleStateProvider<SP: StateProvider, EDP: ExecutionDataProvider> {
+    /// The inner state provider.
+    pub state_provider: SP,
+    /// Block execution data.
+    pub block_execution_data_provider: EDP,
+    /// Cache metrics.
+    pub cache_metrics: CacheMetrics,
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> CachedBundleStateProvider<SP, EDP> {
+    /// Create new cached bundle state provider
+    pub(crate) fn new(state_provider: SP, block_execution_data_provider: EDP) -> Self {
+        Self {
+            state_provider,
+            block_execution_data_provider,
+            cache_metrics: CacheMetrics::default(),
+        }
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> BlockHashReader
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn block_hash(&self, block_number: BlockNumber) -> ProviderResult<Option<B256>> {
+        let block_hash = self.block_execution_data_provider.block_hash(block_number);
+        if block_hash.is_some() {
+            return Ok(block_hash)
+        }
+        self.state_provider.block_hash(block_number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        _start: BlockNumber,
+        _end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        unimplemented!()
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> AccountReader
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
+        if let Some(account) =
+            self.block_execution_data_provider.execution_outcome().account(&address)
+        {
+            Ok(account)
+        } else {
+            self.cache_metrics.account_access_total.increment(1);
+
+            let cached = ACCOUNT_CACHE.get(&address);
+            return match cached {
+                Some(account) => {
+                    debug!(target: "blockchain_tree", address = ?address.to_string(), "Hit blockchain tree account cache");
+                    self.cache_metrics.account_cache_hit_total.increment(1);
+                    Ok(Some(account))
+                }
+                None => {
+                    let db_value = AccountReader::basic_account(&self.state_provider, address);
+                    match db_value {
+                        Ok(account) => {
+                            if let Some(_) = account {
+                                ACCOUNT_CACHE.insert(address, account.unwrap());
+                                debug!(target: "blockchain_tree", address = ?address.to_string(), "Add blockchain tree account cache");
+                            }
+                            Ok(account)
+                        }
+                        Err(err) => Err(err.into()),
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn state_root(&self, bundle_state: &BundleState) -> ProviderResult<B256> {
+        let mut state = self.block_execution_data_provider.execution_outcome().state().clone();
+        state.extend(bundle_state.clone());
+        self.state_provider.state_root(&state)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        bundle_state: &BundleState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let mut state = self.block_execution_data_provider.execution_outcome().state().clone();
+        state.extend(bundle_state.clone());
+        self.state_provider.state_root_with_updates(&state)
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProofProvider
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn proof(
+        &self,
+        bundle_state: &BundleState,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        let mut state = self.block_execution_data_provider.execution_outcome().state().clone();
+        state.extend(bundle_state.clone());
+        self.state_provider.proof(&state, address, slots)
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProvider
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: reth_primitives::StorageKey,
+    ) -> ProviderResult<Option<reth_primitives::StorageValue>> {
+        let u256_storage_key = storage_key.into();
+        if let Some(value) = self
+            .block_execution_data_provider
+            .execution_outcome()
+            .storage(&account, u256_storage_key)
+        {
+            return Ok(Some(value))
+        }
+
+        self.cache_metrics.storage_access_total.increment(1);
+
+        let mut cached = STORAGE_CACHE.get(&account).unwrap_or_else(|| HashMap::new());
+
+        if let Some(v) = cached.get(&storage_key) {
+            debug!(target: "blockchain_tree", address = ?account.to_string(), storage_key = ?storage_key, "Hit blockchain tree storage cache");
+            self.cache_metrics.storage_cache_hit_total.increment(1);
+            return Ok(Some(*v))
+        }
+
+        if let Some(value) = StateProvider::storage(&self.state_provider, account, storage_key)? {
+            cached.insert(storage_key, value);
+            STORAGE_CACHE.insert(account, cached);
+            debug!(target: "blockchain_tree", address = ?account.to_string(), storage_key = ?storage_key, "Add blockchain tree cache case");
+            return Ok(Some(value))
+        }
+        Ok(None)
+    }
+
+    fn bytecode_by_hash(&self, code_hash: B256) -> ProviderResult<Option<Bytecode>> {
+        if let Some(bytecode) =
+            self.block_execution_data_provider.execution_outcome().bytecode(&code_hash)
+        {
+            return Ok(Some(bytecode))
+        }
+
+        self.state_provider.bytecode_by_hash(code_hash)
+    }
+}

--- a/crates/blockchain-tree/src/lib.rs
+++ b/crates/blockchain-tree/src/lib.rs
@@ -54,6 +54,7 @@ pub use block_buffer::BlockBuffer;
 /// Implementation of Tree traits that does nothing.
 pub mod noop;
 
+mod execution_cache;
 mod state;
 
 use aquamarine as _;

--- a/crates/stages/api/src/metrics/listener.rs
+++ b/crates/stages/api/src/metrics/listener.rs
@@ -35,6 +35,17 @@ pub enum MetricEvent {
         /// Gas processed.
         gas: u64,
     },
+    /// Execution cache total access and hits.
+    ExecutionCache {
+        /// Account access
+        account_access: bool,
+        /// Account access hit cache
+        account_hit: bool,
+        /// Storage access
+        storage_access: bool,
+        /// Storage access hit cache
+        storage_hit: bool,
+    },
 }
 
 /// Metrics routine that listens to new metric events on the `events_rx` receiver.
@@ -84,6 +95,25 @@ impl MetricsListener {
             }
             MetricEvent::ExecutionStageGas { gas } => {
                 self.sync_metrics.execution_stage.mgas_processed_total.increment(gas / MEGAGAS)
+            }
+            MetricEvent::ExecutionCache {
+                account_access,
+                account_hit,
+                storage_access,
+                storage_hit,
+            } => {
+                if account_access {
+                    self.sync_metrics.execution_cache.account_access_total.increment(1);
+                }
+                if account_hit {
+                    self.sync_metrics.execution_cache.account_cache_hit_total.increment(1);
+                }
+                if storage_access {
+                    self.sync_metrics.execution_cache.storage_access_total.increment(1);
+                }
+                if storage_hit {
+                    self.sync_metrics.execution_cache.storage_cache_hit_total.increment(1);
+                }
             }
         }
     }

--- a/crates/stages/api/src/metrics/sync_metrics.rs
+++ b/crates/stages/api/src/metrics/sync_metrics.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 pub(crate) struct SyncMetrics {
     pub(crate) stages: HashMap<StageId, StageMetrics>,
     pub(crate) execution_stage: ExecutionStageMetrics,
+    pub(crate) execution_cache: ExecutionCacheMetrics,
 }
 
 impl SyncMetrics {
@@ -38,4 +39,18 @@ pub(crate) struct StageMetrics {
 pub(crate) struct ExecutionStageMetrics {
     /// The total amount of gas processed (in millions)
     pub(crate) mgas_processed_total: Counter,
+}
+
+/// Execution stage cache metrics.
+#[derive(Metrics)]
+#[metrics(scope = "sync.execution.cache")]
+pub(crate) struct ExecutionCacheMetrics {
+    /// Total account access count
+    pub(crate) account_access_total: Counter,
+    /// Total account access cache hit count
+    pub(crate) account_cache_hit_total: Counter,
+    /// Total storage access count
+    pub(crate) storage_access_total: Counter,
+    /// Total storage access cache hit count
+    pub(crate) storage_cache_hit_total: Counter,
 }

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -48,6 +48,9 @@ itertools.workspace = true
 rayon.workspace = true
 num-traits = "0.2.15"
 tempfile = { workspace = true, optional = true }
+lru = "0.12.3"
+parking_lot = "0.12.3"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 # reth

--- a/crates/stages/stages/src/stages/execution_cache.rs
+++ b/crates/stages/stages/src/stages/execution_cache.rs
@@ -1,0 +1,217 @@
+use std::{collections::HashMap, num::NonZeroUsize};
+
+use lazy_static::lazy_static;
+use lru::LruCache;
+use parking_lot::RwLock;
+use tracing::debug;
+
+use reth_db_api::transaction::DbTx;
+use reth_primitives::{Account, Address, BlockNumber, Bytecode, StorageKey, StorageValue, B256};
+use reth_provider::{
+    AccountReader, BlockHashReader, LatestStateProviderRef, StateProofProvider, StateProvider,
+    StateRootProvider,
+};
+use reth_revm::db::{states::StateChangeset, BundleState};
+use reth_stages_api::{MetricEvent, MetricEventsSender};
+use reth_storage_errors::provider::ProviderResult;
+use reth_trie::{updates::TrieUpdates, AccountProof};
+
+/// The size of cache, counted by the number of accounts.
+const CACHE_SIZE: usize = 10240;
+
+lazy_static! {
+    /// Account cache
+    static ref ACCOUNT_CACHE: RwLock<LruCache<Address, Account>> = RwLock::new(LruCache::new(NonZeroUsize::new(CACHE_SIZE).unwrap()));
+
+    /// Storage cache
+    static ref STORAGE_CACHE: RwLock<LruCache<Address, HashMap<StorageKey, StorageValue>>> = RwLock::new(LruCache::new(NonZeroUsize::new(CACHE_SIZE).unwrap()));
+}
+
+pub(crate) fn apply_changeset_to_cache(change_set: StateChangeset) {
+    let mut account_binding = ACCOUNT_CACHE.write();
+    let mut storage_binding = STORAGE_CACHE.write();
+
+    for (address, account_info) in change_set.accounts.iter() {
+        match account_info {
+            None => {
+                account_binding.pop_entry(address);
+                storage_binding.pop_entry(address);
+            }
+            Some(acc) => {
+                account_binding.put(
+                    *address,
+                    Account {
+                        nonce: acc.nonce,
+                        balance: acc.balance,
+                        bytecode_hash: Some(acc.code_hash),
+                    },
+                );
+            }
+        }
+    }
+
+    for storage in change_set.storage.iter() {
+        if storage.wipe_storage {
+            storage_binding.pop_entry(&storage.address);
+        } else {
+            let mut map = HashMap::new();
+            for (k, v) in storage.storage.clone() {
+                map.insert(k.into(), v);
+            }
+            storage_binding.put(storage.address, map);
+        }
+    }
+}
+
+pub(crate) fn clear_cache() {
+    let mut account_binding = ACCOUNT_CACHE.write();
+    account_binding.clear();
+
+    let mut storage_binding = STORAGE_CACHE.write();
+    storage_binding.clear();
+}
+
+/// State provider over latest state that takes tx reference.
+#[derive(Debug)]
+pub(crate) struct CachedLatestStateProviderRef<'b, TX: DbTx> {
+    provider: LatestStateProviderRef<'b, TX>,
+    metrics_tx: Option<MetricEventsSender>,
+}
+
+impl<'b, TX: DbTx> CachedLatestStateProviderRef<'b, TX> {
+    /// Create new state provider
+    pub(crate) fn new(
+        provider: LatestStateProviderRef<'b, TX>,
+        metrics_tx: Option<MetricEventsSender>,
+    ) -> Self {
+        Self { provider, metrics_tx }
+    }
+}
+
+impl<'b, TX: DbTx> AccountReader for CachedLatestStateProviderRef<'b, TX> {
+    /// Get basic account information.
+    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
+        if let Some(metrics_tx) = &self.metrics_tx {
+            let _ = metrics_tx.send(MetricEvent::ExecutionCache {
+                account_access: true,
+                account_hit: false,
+                storage_access: false,
+                storage_hit: false,
+            });
+        }
+        let mut binding = ACCOUNT_CACHE.write();
+        let cached = binding.get(&address);
+        return match cached {
+            Some(account) => {
+                debug!(target: "sync::stages::execution", address = ?address.to_string(), "Hit execution stage account cache");
+                if let Some(metrics_tx) = &self.metrics_tx {
+                    let _ = metrics_tx.send(MetricEvent::ExecutionCache {
+                        account_access: false,
+                        account_hit: true,
+                        storage_access: false,
+                        storage_hit: false,
+                    });
+                }
+                Ok(Some(*account))
+            }
+            None => {
+                let db_value = AccountReader::basic_account(&self.provider, address);
+                match db_value {
+                    Ok(account) => {
+                        if let Some(_) = account {
+                            binding.put(address, account.unwrap());
+                            debug!(target: "sync::stages::execution", address = ?address.to_string(), "Add execution stage account cache");
+                        }
+                        Ok(account)
+                    }
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    }
+}
+
+impl<'b, TX: DbTx> BlockHashReader for CachedLatestStateProviderRef<'b, TX> {
+    /// Get block hash by number.
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        BlockHashReader::block_hash(&self.provider, number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.provider.canonical_hashes_range(start, end)
+    }
+}
+
+impl<'b, TX: DbTx> StateRootProvider for CachedLatestStateProviderRef<'b, TX> {
+    fn state_root(&self, bundle_state: &BundleState) -> ProviderResult<B256> {
+        self.provider.state_root(bundle_state)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        bundle_state: &BundleState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.provider.state_root_with_updates(bundle_state)
+    }
+}
+
+impl<'b, TX: DbTx> StateProofProvider for CachedLatestStateProviderRef<'b, TX> {
+    fn proof(
+        &self,
+        bundle_state: &BundleState,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        self.provider.proof(bundle_state, address, slots)
+    }
+}
+
+impl<'b, TX: DbTx> StateProvider for CachedLatestStateProviderRef<'b, TX> {
+    /// Get storage.
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        if let Some(metrics_tx) = &self.metrics_tx {
+            let _ = metrics_tx.send(MetricEvent::ExecutionCache {
+                account_access: false,
+                account_hit: false,
+                storage_access: true,
+                storage_hit: false,
+            });
+        }
+
+        let mut binding = STORAGE_CACHE.write();
+        let cached = binding.get_or_insert_mut(account, || HashMap::new());
+
+        if let Some(v) = cached.get(&storage_key) {
+            debug!(target: "sync::stages::execution", address = ?account.to_string(), storage_key = ?storage_key, "Hit execution stage storage cache");
+            if let Some(metrics_tx) = &self.metrics_tx {
+                let _ = metrics_tx.send(MetricEvent::ExecutionCache {
+                    account_access: false,
+                    account_hit: false,
+                    storage_access: false,
+                    storage_hit: true,
+                });
+            }
+            return Ok(Some(*v))
+        }
+
+        if let Some(value) = StateProvider::storage(&self.provider, account, storage_key)? {
+            cached.insert(storage_key, value);
+            debug!(target: "sync::stages::execution", address = ?account.to_string(), storage_key = ?storage_key, "Add execution stage storage cache");
+            return Ok(Some(value))
+        }
+        Ok(None)
+    }
+
+    /// Get account code by its hash
+    fn bytecode_by_hash(&self, code_hash: B256) -> ProviderResult<Option<Bytecode>> {
+        StateProvider::bytecode_by_hash(&self.provider, code_hash)
+    }
+}

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -34,7 +34,9 @@ pub use merkle::*;
 pub use sender_recovery::*;
 pub use tx_lookup::*;
 
+mod execution_cache;
 mod utils;
+
 use utils::*;
 
 #[cfg(test)]


### PR DESCRIPTION
### Description

Try to add another layer of cache.

### Rationale
In geth, there are three layers of cache for block importing
- l1 - cached accounts/storages for the current block execution
- l2 - cached accounts/storages in difflayers
- l3 - fast cache for database access

Currently, there are revm `state` for stage sync (kind of l1&l2 cache); and there are revm `state` and `bundle state` for live sync (kind of l1&l2 cache). This pr tries to add l3 cache for stage and live sync.

### Example

Initial result is not good.

#### Stage sync with bsc testnet (from 500W to 1000W blocks)
```
account hit rate: 878770/26073429 = 3.37%
reth_sync_execution_cache_storage_cache_hit_total 878770
reth_sync_execution_cache_storage_access_total 26073429

storage hit rate: 15310/2696478 = 0.568%
reth_sync_execution_cache_account_cache_hit_total 15310
reth_sync_execution_cache_account_access_total 2696478
```

Execution stage time: 

- cache version: 38m
- no cache used: 36m

#### Live sync with opbnb testnet (from 1 to ~15500 blocks, FCU updates)
```
account hit rate: 47520/47595 = 99.8%
reth_blockchain_tree_cache_account_cache_hit_total 47520
reth_blockchain_tree_cache_account_access_total 47595

storage hit rate: 30815/126132 = 24.4%
reth_blockchain_tree_cache_storage_cache_hit_total 30815
reth_blockchain_tree_cache_storage_access_total 126132
```
- cache version:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/f5fef041-d4c9-4d07-bd04-0187a8fe72ba">


- no cache version
<img width="845" alt="image" src="https://github.com/user-attachments/assets/bbfe6559-b797-4fdd-bd44-eac9ca3db287">


It seems that sometimes the cached version is better, and sometimes it is much worse. Overall, the execution time does not decrease usually.

### Changes

Notable changes: 
* NA
