### PR TITLE
fix: check parent hash of disconnected headers

### DIFF
--- a/crates/bsc/engine/src/task.rs
+++ b/crates/bsc/engine/src/task.rs
@@ -310,6 +310,13 @@ impl<
                         }
                         disconnected_headers.push(sealed_header.clone());
                     }
+
+                    // check last header.parent_hash is match the trusted header
+                    if !disconnected_headers.is_empty() &&
+                        disconnected_headers.last().unwrap().parent_hash != trusted_header.hash()
+                    {
+                        continue;
+                    }
                 };
 
                 // cache header and block


### PR DESCRIPTION
### Description

check parent hash of disconnected headers

### Rationale

check the parent hash of disconnected headers to prevent header discontinuities

### Example

n/a

### Changes

Notable changes: 
* bsc-engine/task

### Potential Impacts
* no
