### PR TITLE
release: prepare for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.0.0
+The Reth is entering production-ready v1.0.0. Thanks to the Paradigm team for their continuous iterations on Reth, 
+providing the community with a highly scalable, modular, high-performance, and feature-rich client. 
+We stand on the shoulders of giants, enabling us to swiftly launch the Reth supporting BSC and opBNB network versions.
+
+### BUGFIX
+* [\#75](https://github.com/bnb-chain/reth/pull/75) ci: fix release job
+* [\#76](https://github.com/bnb-chain/reth/pull/76) chore: update max db size 
+* [\#74](https://github.com/bnb-chain/reth/pull/74) fix: add sidecars to db when doing insert_block 
+* [\#79](https://github.com/bnb-chain/reth/pull/79) fix: read sidecars from table in get_take_block_range
+* [\#81](https://github.com/bnb-chain/reth/pull/81) fix: check parent hash of disconnected headers 
+* [\#83](https://github.com/bnb-chain/reth/pull/83) fix: parlia live sync issue
+* [\#89](https://github.com/bnb-chain/reth/pull/89) fix: fork block handling in parlia engine and rewinding blocks to the block before the finalized block issue
+
+### Docs
+* [\#87](https://github.com/bnb-chain/reth/pull/87) chore: refine readme file
+* [\#90](https://github.com/bnb-chain/reth/pull/90) doc: fix op-reth running tutorial
+
+
 ## v1.0.0-rc.2
 
 This release is a release candidate for the v1.0.0 release. It includes a number of new features and bug fixes.

--- a/README.md
+++ b/README.md
@@ -53,26 +53,29 @@ make install-op
 
 ## Run Reth for BSC
 
+### Hardware Requirements
+
+* CPU with 16+ cores
+* 128GB RAM
+* High-performance NVMe SSD with at least 4TB of free space for full node and 8TB of free space for archive node
+* A broadband internet connection with upload/download speeds of 25 MB/s
+
+### Steps to Run bsc-reth
+
 The command below is for an archive node. To run a full node, simply add the `--full` tag.
 
 ```shell
-# for testnet
-export network=bsc-testnet
-
 # for mainnet
-# export network=bsc
+export network=bsc
+
+# for testnet
+# export network=bsc-testnet
 
 ./target/release/bsc-reth node \
     --datadir=./datadir \
     --chain=${network} \
     --http \
-    --http.addr=0.0.0.0 \
-    --http.port=8545 \
     --http.api="eth, net, txpool, web3, rpc" \
-    --ws \
-    --ws.addr=0.0.0.0 \
-    --ws.port=8546 \
-    --nat=any \
     --log.file.directory ./datadir/logs
 ```
 
@@ -81,11 +84,11 @@ You can run `bsc-reth --help` for command explanations.
 For running bsc-reth with docker, please use the following command:
 
 ```shell
-# for testnet
-export network=bsc-testnet
-
 # for mainnet
-# export network=bsc
+export network=bsc
+
+# for testnet
+# export network=bsc-testnet
 
 # check this for version of the docker image, https://github.com/bnb-chain/reth/pkgs/container/bsc-reth
 export version=latest
@@ -93,24 +96,25 @@ export version=latest
 # the directory where reth data will be stored
 export data_dir=/xxx/xxx
 
-docker run -d -p 8545:8545 -p 8546:8546 -p 30303:30303 -p 30303:30303/udp -v ${data_dir}:/data \
+docker run -d -p 8545:8545 -p 30303:30303 -p 30303:30303/udp -v ${data_dir}:/data \
     --name bsc-reth ghcr.io/bnb-chain/bsc-reth:${version} node \
     --datadir=/data \
     --chain=${network} \
     --http \
-    --http.addr=0.0.0.0 \
-    --http.port=8545 \
     --http.api="eth, net, txpool, web3, rpc" \
-    --ws \
-    --ws.addr=0.0.0.0 \
-    --ws.port=8546 \
-    --nat=any \
     --log.file.directory /data/logs
 ```
 
+### Snapshots
+
+There are snapshots available from the community, you can use a snapshot to reduce the sync time for catching up.
+
+* [fuzzland snapshot](https://github.com/fuzzland/snapshots)
+
 ## Run Reth for opBNB
 
-The op-reth can function as both a full node and an archive node. Due to its unique storage advantages, it is primarily utilized for running archive nodes.
+The op-reth can function as both a full node and an archive node. Due to its unique storage advantages, it is primarily
+utilized for running archive nodes.
 
 ### Hardware Requirements
 
@@ -133,16 +137,16 @@ git clone https://github.com/bnb-chain/opbnb
 cd opbnb
 make op-node
 
+# for mainnet
+export network=mainnet
+export L1_RPC=https://bsc-dataseed.bnbchain.org
+export P2P_BOOTNODES="enr:-J24QA9sgVxbZ0KoJ7-1gx_szfc7Oexzz7xL2iHS7VMHGj2QQaLc_IQZmFthywENgJWXbApj7tw7BiouKDOZD4noWEWGAYppffmvgmlkgnY0gmlwhDbjSM6Hb3BzdGFja4PMAQCJc2VjcDI1NmsxoQKetGQX7sXd4u8hZr6uayTZgHRDvGm36YaryqZkgnidS4N0Y3CCIyuDdWRwgiMs,enr:-J24QPSZMaGw3NhO6Ll25cawknKcOFLPjUnpy72HCkwqaHBKaaR9ylr-ejx20INZ69BLLj334aEqjNHKJeWhiAdVcn-GAYv28FmZgmlkgnY0gmlwhDTDWQOHb3BzdGFja4PMAQCJc2VjcDI1NmsxoQJ-_5GZKjs7jaB4TILdgC8EwnwyL3Qip89wmjnyjvDDwoN0Y3CCIyuDdWRwgiMs"
+
 # for testnet
 # it's better to replace the L1_RPC with your own BSC Testnet RPC Endpoint for stability
-export network=testnet
-export L1_RPC=https://bsc-testnet.bnbchain.org
-export P2P_BOOTNODES="enr:-J24QGQBeMsXOaCCaLWtNFSfb2Gv50DjGOKToH2HUTAIn9yXImowlRoMDNuPNhSBZNQGCCE8eAl5O3dsONuuQp5Qix2GAYjB7KHSgmlkgnY0gmlwhDREiqaHb3BzdGFja4PrKwCJc2VjcDI1NmsxoQL4I9wpEVDcUb8bLWu6V8iPoN5w8E8q-GrS5WUCygYUQ4N0Y3CCIyuDdWRwgiMr,enr:-J24QJKXHEkIhy0tmIk2EscMZ2aRrivNsZf_YhgIU51g4ZKHWY0BxW6VedRJ1jxmneW9v7JjldPOPpLkaNSo6cXGFxqGAYpK96oCgmlkgnY0gmlwhANzx96Hb3BzdGFja4PrKwCJc2VjcDI1NmsxoQMOCzUFffz04eyDrmkbaSCrMEvLvn5O4RZaZ5k1GV4wa4N0Y3CCIyuDdWRwgiMr"
-
-# for mainnet
-# export network=mainnet
-# export L1_RPC=https://bsc-dataseed.bnbchain.org
-# export P2P_BOOTNODES="enr:-J24QA9sgVxbZ0KoJ7-1gx_szfc7Oexzz7xL2iHS7VMHGj2QQaLc_IQZmFthywENgJWXbApj7tw7BiouKDOZD4noWEWGAYppffmvgmlkgnY0gmlwhDbjSM6Hb3BzdGFja4PMAQCJc2VjcDI1NmsxoQKetGQX7sXd4u8hZr6uayTZgHRDvGm36YaryqZkgnidS4N0Y3CCIyuDdWRwgiMs,enr:-J24QPSZMaGw3NhO6Ll25cawknKcOFLPjUnpy72HCkwqaHBKaaR9ylr-ejx20INZ69BLLj334aEqjNHKJeWhiAdVcn-GAYv28FmZgmlkgnY0gmlwhDTDWQOHb3BzdGFja4PMAQCJc2VjcDI1NmsxoQJ-_5GZKjs7jaB4TILdgC8EwnwyL3Qip89wmjnyjvDDwoN0Y3CCIyuDdWRwgiMs"
+# export network=testnet
+# export L1_RPC=https://bsc-testnet.bnbchain.org
+# export P2P_BOOTNODES="enr:-J24QGQBeMsXOaCCaLWtNFSfb2Gv50DjGOKToH2HUTAIn9yXImowlRoMDNuPNhSBZNQGCCE8eAl5O3dsONuuQp5Qix2GAYjB7KHSgmlkgnY0gmlwhDREiqaHb3BzdGFja4PrKwCJc2VjcDI1NmsxoQL4I9wpEVDcUb8bLWu6V8iPoN5w8E8q-GrS5WUCygYUQ4N0Y3CCIyuDdWRwgiMr,enr:-J24QJKXHEkIhy0tmIk2EscMZ2aRrivNsZf_YhgIU51g4ZKHWY0BxW6VedRJ1jxmneW9v7JjldPOPpLkaNSo6cXGFxqGAYpK96oCgmlkgnY0gmlwhANzx96Hb3BzdGFja4PrKwCJc2VjcDI1NmsxoQMOCzUFffz04eyDrmkbaSCrMEvLvn5O4RZaZ5k1GV4wa4N0Y3CCIyuDdWRwgiMr"
 
 ./op-node/bin/op-node \
   --l1.trustrpc \
@@ -175,13 +179,13 @@ op-reth.
 The command below is for an archive node. To run a full node, simply add the `--full` tag.
 
 ```shell
-# for testnet
-export network=testnet
-export L2_RPC=https://opbnb-testnet-rpc.bnbchain.org
-
 # for mainnet
-# export network=mainnet
-# export L2_RPC=https://opbnb-mainnet-rpc.bnbchain.org
+export network=mainnet
+export L2_RPC=https://opbnb-mainnet-rpc.bnbchain.org
+
+# for testnet
+# export network=testnet
+# export L2_RPC=https://opbnb-testnet-rpc.bnbchain.org
 
 ./target/release/op-reth node \
     --datadir=./datadir \
@@ -191,14 +195,7 @@ export L2_RPC=https://opbnb-testnet-rpc.bnbchain.org
     --authrpc.port=8551 \
     --authrpc.jwtsecret=./jwt.txt \
     --http \
-    --http.addr=0.0.0.0 \
-    --http.port=8545 \
     --http.api="eth, net, txpool, web3, rpc" \
-    --ws \
-    --ws.addr=0.0.0.0 \
-    --ws.port=8546 \
-    --builder.gaslimit=150000000 \
-    --nat=any \
     --log.file.directory ./datadir/logs
 ```
 
@@ -208,13 +205,13 @@ found [here](https://docs.bnbchain.org/opbnb-docs/docs/tutorials/running-a-local
 For running op-reth with docker, please use the following command:
 
 ```shell
-# for testnet
-export network=testnet
-export L2_RPC=https://opbnb-testnet-rpc.bnbchain.org
-
 # for mainnet
-# export network=mainnet
-# export L2_RPC=https://opbnb-mainnet-rpc.bnbchain.org
+export network=mainnet
+export L2_RPC=https://opbnb-mainnet-rpc.bnbchain.org
+
+# for testnet
+# export network=testnet
+# export L2_RPC=https://opbnb-testnet-rpc.bnbchain.org
 
 # check this for version of the docker image, https://github.com/bnb-chain/reth/pkgs/container/op-reth
 export version=latest
@@ -225,7 +222,7 @@ export data_dir=/xxx/xxx
 # the directory where the jwt.txt file is stored
 export jwt_dir=/xxx/xxx
 
-docker run -d -p 8545:8545 -p 8546:8546 -p 30303:30303 -p 30303:30303/udp -v ${data_dir}:/data -v ${jwt_dir}:/jwt \
+docker run -d -p 8545:8545 -p 30303:30303 -p 30303:30303/udp -v ${data_dir}:/data -v ${jwt_dir}:/jwt \
     --name op-reth ghcr.io/bnb-chain/op-reth:${version} node \
     --datadir=/data \
     --chain=opbnb-${network} \
@@ -234,14 +231,7 @@ docker run -d -p 8545:8545 -p 8546:8546 -p 30303:30303 -p 30303:30303/udp -v ${d
     --authrpc.port=8551 \
     --authrpc.jwtsecret=/jwt/jwt.txt \
     --http \
-    --http.addr=0.0.0.0 \
-    --http.port=8545 \
     --http.api="eth, net, txpool, web3, rpc" \
-    --ws \
-    --ws.addr=0.0.0.0 \
-    --ws.port=8546 \
-    --builder.gaslimit=150000000 \
-    --nat=any \
     --log.file.directory /data/logs
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ utilized for running archive nodes.
 ### Steps to Run op-reth
 
 The op-reth is an [execution client](https://ethereum.org/en/developers/docs/nodes-and-clients/#execution-clients) for
-opBNB.
-You need to run op-node along with op-reth to synchronize with the opBNB network.
+opBNB. You need to run op-node along with op-reth to synchronize with the opBNB network.
 
 Here is the quick command for running the op-node. For more details, refer to
 the [opbnb repository](https://github.com/bnb-chain/opbnb).
@@ -171,12 +170,16 @@ export P2P_BOOTNODES="enr:-J24QA9sgVxbZ0KoJ7-1gx_szfc7Oexzz7xL2iHS7VMHGj2QQaLc_I
   --rpc.enable-admin \
   --l1=${L1_RPC} \
   --l2=http://localhost:8551 \
-  --l2.jwt-secret=./jwt.txt
+  --l2.jwt-secret=./jwt.txt \
+  --syncmode=execution-layer
 ```
 
-Copy the JWT file generated when running the op-node to the current workspace. Here is a quick command for running
-op-reth.
-The command below is for an archive node. To run a full node, simply add the `--full` tag.
+**It's important to mention that op-node and op-reth both need the same jwt.txt file.**
+To do this, switch to the op-reth workdir and paste the jwt.txt file created during op-node execution into the current
+workspace.
+
+Here is a quick command for running op-reth. The command below is for an archive node, to run a full node, simply add
+the `--full` tag.
 
 ```shell
 # for mainnet

--- a/crates/bsc/engine/src/task.rs
+++ b/crates/bsc/engine/src/task.rs
@@ -310,6 +310,13 @@ impl<
                         }
                         disconnected_headers.push(sealed_header.clone());
                     }
+
+                    // check last header.parent_hash is match the trusted header
+                    if !disconnected_headers.is_empty() &&
+                        disconnected_headers.last().unwrap().parent_hash != trusted_header.hash()
+                    {
+                        continue;
+                    }
                 };
 
                 // cache header and block

--- a/crates/bsc/engine/src/task.rs
+++ b/crates/bsc/engine/src/task.rs
@@ -20,6 +20,7 @@ use std::{
 };
 use tokio::sync::Mutex;
 
+use reth_rpc_types::{BlockId, RpcBlockHash};
 use tokio::{
     signal,
     sync::{
@@ -40,7 +41,7 @@ enum ForkChoiceMessage {
 #[derive(Debug, Clone)]
 struct NewHeaderEvent {
     header: SealedHeader,
-    trusted_header: SealedHeader,
+    local_header: SealedHeader,
     pipeline_sync: bool,
 }
 
@@ -147,6 +148,7 @@ impl<
             loop {
                 let read_storage = storage.read().await;
                 let best_header = read_storage.best_header.clone();
+                let finalized_hash = read_storage.best_finalized_hash;
                 drop(read_storage);
                 let mut engine_rx_guard = engine_rx.lock().await;
                 let mut info = BlockInfo {
@@ -231,19 +233,25 @@ impl<
                     }
                 }
                 let latest_header = header_option.unwrap();
-
-                // skip if parent hash is not equal to best hash
-                if latest_header.number == best_header.number + 1 &&
-                    latest_header.parent_hash != best_header.hash()
-                {
-                    continue;
-                }
-
-                let trusted_header = client
+                let finalized_header = client
+                    .sealed_header_by_id(BlockId::Hash(RpcBlockHash::from(finalized_hash)))
+                    .ok()
+                    .flatten()
+                    .unwrap_or_else(|| chain_spec.sealed_genesis_header());
+                debug!(target: "consensus::parlia", { finalized_header_number = ?finalized_header.number, finalized_header_hash = ?finalized_header.hash() }, "Latest finalized header");
+                let latest_unsafe_header = client
                     .latest_header()
                     .ok()
                     .flatten()
                     .unwrap_or_else(|| chain_spec.sealed_genesis_header());
+                debug!(target: "consensus::parlia", { latest_unsafe_header_number = ?latest_unsafe_header.number, latest_unsafe_header_hash = ?latest_unsafe_header.hash() }, "Latest unsafe header");
+
+                let mut trusted_header = latest_unsafe_header.clone();
+                // if parent hash is not equal to latest unsafe hash
+                // may be a fork chain detected, we need to trust the finalized header
+                if latest_header.parent_hash != latest_unsafe_header.hash() {
+                    trusted_header = finalized_header.clone();
+                }
 
                 // verify header and timestamp
                 // predict timestamp is the trusted header timestamp plus the block interval times
@@ -354,7 +362,7 @@ impl<
                             // and finalized hash.
                             // this can make Block Sync Engine to use pipeline sync mode.
                             pipeline_sync,
-                            trusted_header: trusted_header.clone(),
+                            local_header: latest_unsafe_header.clone(),
                         }));
                     if result.is_err() {
                         error!(target: "consensus::parlia", "Failed to send new block event to
@@ -366,7 +374,7 @@ impl<
                 let result = chain_tracker_tx.send(ForkChoiceMessage::NewHeader(NewHeaderEvent {
                     header: sealed_header.clone(),
                     pipeline_sync,
-                    trusted_header: trusted_header.clone(),
+                    local_header: latest_unsafe_header.clone(),
                 }));
                 if result.is_err() {
                     error!(target: "consensus::parlia", "Failed to send new block event to chain tracker");
@@ -476,7 +484,7 @@ impl<
                         }
                         match msg.unwrap() {
                             ForkChoiceMessage::NewHeader(event) => {
-                                let new_header = event.trusted_header;
+                                let new_header = event.local_header;
 
                                 let snap = match snapshot_reader.snapshot(&new_header, None) {
                                     Ok(snap) => snap,

--- a/crates/consensus/beacon/src/engine/hooks/static_file.rs
+++ b/crates/consensus/beacon/src/engine/hooks/static_file.rs
@@ -142,6 +142,15 @@ impl<DB: Database + 'static> EngineHook for StaticFileHook<DB> {
             return Poll::Pending
         };
 
+        // The chain state may be rewind, if the finalized block number is greater than the tip
+        // block number. In this case, we should wait until the finalized block number is
+        // less than or equal to the tip block number. To prevent the static file producer
+        // from producing static files for the wrong block and incrementing the index number.
+        if finalized_block_number >= ctx.tip_block_number {
+            trace!(target: "consensus::engine::hooks::static_file", ?ctx, "Finalized block number is greater than tip number");
+            return Poll::Pending
+        }
+
         // Try to spawn a static_file_producer
         match self.try_spawn_static_file_producer(finalized_block_number)? {
             Some(EngineHookEvent::NotReady) => return Poll::Pending,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -969,6 +969,7 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         let block_withdrawals =
             self.get_or_take::<tables::BlockWithdrawals, TAKE>(range.clone())?;
         let block_requests = self.get_or_take::<tables::BlockRequests, TAKE>(range.clone())?;
+        let block_sidecars = self.get_or_take::<tables::Sidecars, TAKE>(range.clone())?;
 
         let block_tx = self.get_take_block_transaction_range::<TAKE>(range.clone())?;
 
@@ -993,9 +994,11 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
         let mut block_ommers_iter = block_ommers.into_iter();
         let mut block_withdrawals_iter = block_withdrawals.into_iter();
         let mut block_requests_iter = block_requests.into_iter();
+        let mut block_sidecars_iter = block_sidecars.into_iter();
         let mut block_ommers = block_ommers_iter.next();
         let mut block_withdrawals = block_withdrawals_iter.next();
         let mut block_requests = block_requests_iter.next();
+        let mut block_sidecars = block_sidecars_iter.next();
 
         let mut blocks = Vec::new();
         for ((main_block_number, header), (_, header_hash), (_, tx)) in
@@ -1044,10 +1047,17 @@ impl<TX: DbTxMut + DbTx> DatabaseProvider<TX> {
             }
 
             // sidecars can be missing
-            let sidecars = if self.chain_spec.is_cancun_active_at_timestamp(header.timestamp) {
-                self.static_file_provider.sidecars(&header.hash())?
+            let cancun_is_active = self.chain_spec.is_cancun_active_at_timestamp(header.timestamp);
+            let mut sidecars = Some(BlobSidecars::default());
+            if cancun_is_active {
+                if let Some((block_number, _)) = block_sidecars.as_ref() {
+                    if *block_number == main_block_number {
+                        sidecars = Some(block_sidecars.take().unwrap().1);
+                        block_sidecars = block_sidecars_iter.next();
+                    }
+                }
             } else {
-                None
+                sidecars = None;
             };
 
             blocks.push(SealedBlockWithSenders {


### PR DESCRIPTION
### Description
The Reth is entering production-ready v1.0.0. Thanks to the Paradigm team for their continuous iterations on Reth, 
providing the community with a highly scalable, modular, high-performance, and feature-rich client. 
We stand on the shoulders of giants, enabling us to swiftly launch the Reth supporting BSC and opBNB network versions.

### BUGFIX
* [\#75](https://github.com/bnb-chain/reth/pull/75) ci: fix release job
* [\#76](https://github.com/bnb-chain/reth/pull/76) chore: update max db size 
* [\#74](https://github.com/bnb-chain/reth/pull/74) fix: add sidecars to db when doing insert_block 
* [\#79](https://github.com/bnb-chain/reth/pull/79) fix: read sidecars from table in get_take_block_range
* [\#81](https://github.com/bnb-chain/reth/pull/81) fix: check parent hash of disconnected headers 
* [\#83](https://github.com/bnb-chain/reth/pull/83) fix: parlia live sync issue
* [\#89](https://github.com/bnb-chain/reth/pull/89) fix: fork block handling in parlia engine and rewinding blocks to the block before the finalized block issue

### Docs
* [\#87](https://github.com/bnb-chain/reth/pull/87) chore: refine readme file
* [\#90](https://github.com/bnb-chain/reth/pull/90) doc: fix op-reth running tutorial


