### PR TITLE
fix: fork block handling in parlia engine and rewinding blocks to the block before the finalized block issue

### DIFF
--- a/crates/bsc/engine/src/task.rs
+++ b/crates/bsc/engine/src/task.rs
@@ -238,6 +238,7 @@ impl<
                     .ok()
                     .flatten()
                     .unwrap_or_else(|| chain_spec.sealed_genesis_header());
+                debug!(target: "consensus::parlia", { trusted_header_number = ?trusted_header.number, trusted_header_hash = ?trusted_header.hash() }, "Trusted header");
 
                 // verify header and timestamp
                 // predict timestamp is the trusted header timestamp plus the block interval times

--- a/crates/consensus/beacon/src/engine/hooks/static_file.rs
+++ b/crates/consensus/beacon/src/engine/hooks/static_file.rs
@@ -142,6 +142,14 @@ impl<DB: Database + 'static> EngineHook for StaticFileHook<DB> {
             return Poll::Pending
         };
 
+        // The chain state may be rewind, if the finalized block number is greater than the tip block number.
+        // In this case, we should wait until the finalized block number is less than or equal to the tip block number.
+        // To prevent the static file producer from producing static files for the wrong block and incrementing the index number.
+        if finalized_block_number >= ctx.tip_block_number {
+            trace!(target: "consensus::engine::hooks::static_file", ?ctx, "Finalized block number is greater than tip number");
+            return Poll::Pending
+        }
+
         // Try to spawn a static_file_producer
         match self.try_spawn_static_file_producer(finalized_block_number)? {
             Some(EngineHookEvent::NotReady) => return Poll::Pending,

--- a/crates/consensus/beacon/src/engine/hooks/static_file.rs
+++ b/crates/consensus/beacon/src/engine/hooks/static_file.rs
@@ -142,9 +142,10 @@ impl<DB: Database + 'static> EngineHook for StaticFileHook<DB> {
             return Poll::Pending
         };
 
-        // The chain state may be rewind, if the finalized block number is greater than the tip block number.
-        // In this case, we should wait until the finalized block number is less than or equal to the tip block number.
-        // To prevent the static file producer from producing static files for the wrong block and incrementing the index number.
+        // The chain state may be rewind, if the finalized block number is greater than the tip
+        // block number. In this case, we should wait until the finalized block number is
+        // less than or equal to the tip block number. To prevent the static file producer
+        // from producing static files for the wrong block and incrementing the index number.
         if finalized_block_number >= ctx.tip_block_number {
             trace!(target: "consensus::engine::hooks::static_file", ?ctx, "Finalized block number is greater than tip number");
             return Poll::Pending


### PR DESCRIPTION
### Description

1. fork block causes live sync breaking.
2. rewinding blocks to the block before the finalized block issue.

### Rationale

1. We need to trust the finalized hash instead of the latest unsafe hash. 
When the parent hash does not match, we need to obtain and insert the (latest - finalized) blocks to determine whether reorg has occurred.

2. full logs -> [debug.log.3.zip](https://github.com/user-attachments/files/16425914/debug.log.3.zip)
```
{"timestamp":"2024-07-29T17:32:15.331477Z","level":"ERROR","fields":{"message":"Header cannot be attached to known canonical chain","error":"mismatched parent hash: got 0xa9a38fdb6af48eb647288d082a187b039d84011c237085f785af951eef0ff2eb
, expected 0x1a9c657d1cd6981467912fe327f3c4131f3a68c2e03d13fb1b1827cc6daada39","number":40902315,"hash":"0x7c7242f7fece1063d7f201012d98de2194773e4aeeb0bf5675cc5d1dfbf8dda3"},"target":"downloaders::headers"}
{"timestamp":"2024-07-29T17:32:15.331531Z","level":"DEBUG","fields":{"message":"Commencing sync","tip":"Hash(0x0b3f543eb0a50b2ad7617240589535e30860e28356c5f21e3dda9aa520eba9ad)","head":"0x1a9c657d1cd6981467912fe327f3c4131f3a68c2e03d13f
b1b1827cc6daada39"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:15.331572Z","level":"ERROR","fields":{"message":"Cannot attach header to head","error":"mismatched parent hash: got 0xa9a38fdb6af48eb647288d082a187b039d84011c237085f785af951eef0ff2eb, expected 0x1a9c657d1
cd6981467912fe327f3c4131f3a68c2e03d13fb1b1827cc6daada39"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:15.331618Z","level":"WARN","fields":{"message":"Stage encountered detached head","stage":"Headers","local_head":"SealedHeader { hash: 0x1a9c657d1cd6981467912fe327f3c4131f3a68c2e03d13fb1b1827cc6daada39, he
ader: Header { parent_hash: 0x0467972c520437cf3af5283ca39a34fef7225c86c1bf6afae77becefdef25d07, ommers_hash: 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347, beneficiary: 0x75b851a27d7101438f45fce31816501193239a83, s
tate_root: 0x20eab2b25f4bb6dcbabc43c5ab5a4b2465640da11bbb2ef7b4c0658ac492ce65, transactions_root: 0xf98a3b98dce03160af3b4db461324658e5c80dc7bf452ef6ee7a0f0d7cdc5a1e, receipts_root: 0xba828f20357c48ae634fd24e708334788db2f4c9b632dd6c16de
dea9dee1b770, withdrawals_root: Some(0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421), logs_bloom: 0x0525a6f33d619dc5571380d3a11324c9938f613d9d2a07342d3d3ee4084147a49b421a020f82b0d1c431fff2702e6188fa40c3220928a83c78f
0213a8bf6eef3e6c9ccf235e66a88054983d89f022123b11e29219c758a4889555bb2a68c26a4a9280932e3d22145162d603d205c280c880a84f5024f8d53ea4214fcc0598286e85c62324ac240c6c28a2eca472358e9efa4969d4aa8476c015800d1d82a39e842487ccb3f8531740a452b8a23a6a6
c1272507b80082008c01249160fda189eccb8f8fba9f103d0b1183d096377e7a6027fb6128ef09a6514b1645533a34e61085b2ba0b42216a71090e03041e704302b218862a5cfa19cf72831072045fed1a, difficulty: 1, number: 40902314, gas_limit: 140000000, gas_used: 149634
38, timestamp: 1722273730, mix_hash: 0x0000000000000000000000000000000000000000000000000000000000000000, nonce: 0, base_fee_per_gas: Some(0), blob_gas_used: Some(0), excess_blob_gas: Some(0), parent_beacon_block_root: None, requests_ro
ot: None, extra_data: 0xd98301040a846765746889676f312e32312e3131856c696e7578000048fa7b05f8b5831bffffb860b58e3b5c9e7e59523108b4ff705ee6074fa3e0698061e804d2328980871b2e9c857469475a523e17dbef0d89124fe7251377fe1a551bf4dc8f27dd9f0407b88ab13
ca4e58ced6e47fb052951508db6922d47ce4c8180802dc7d05a34cffa22edf84c8402701ea8a053e9d8eb08eefce21a9fd84950a86bf14225c890cc2a4e2f5b1d62570aba7df48402701ea9a00467972c520437cf3af5283ca39a34fef7225c86c1bf6afae77becefdef25d0780c1816761399a91ad
00ec59bbfb64d264c5b17a89eb5766767f665374f0c242bc3198f46fa8199d65f543ace82a5e71c541935a4d661f49e3587b30bd9fe51a2600 } }","header":"SealedHeader { hash: 0x7c7242f7fece1063d7f201012d98de2194773e4aeeb0bf5675cc5d1dfbf8dda3, header: Header {
 parent_hash: 0xa9a38fdb6af48eb647288d082a187b039d84011c237085f785af951eef0ff2eb, ommers_hash: 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347, beneficiary: 0x5009317fd4f6f8feea9dae41e5f0a4737bb7a7d5, state_root: 0x6
725bb838c0a682b4c84a6f4d65c159d1cb6b9916109b31d9176b206c15948c3, transactions_root: 0x96f81f14b66f115e216566acb0f6803091186395fe067d050366a3a9477d762c, receipts_root: 0x04637f0155f90d13fe7689c395158dc5881d819d4597457a317fc3f88c8d48fd, 
withdrawals_root: Some(0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421), logs_bloom: 0x4535b6533cae9884d30788d1911cf25f188b633d812883140d03bee48e02c194904219030a01a010d254ecb6000e4180afc482010ba2e8082a60a12a03b4ccbb5
699c0a31fca4e4e05cfa38981230022311029210574088088176539a20434a4b138103c36823b01164b001583060a0808139c2300cec5d5380080588b0944845856422002c2804202c41652660058a3a1e4368bb1a9427b015800c098401861662c00c3798201209a07f10c63000441a005853411e4
08ccc1001120a7a
988c44c09871e32309c031480908da84f2a4827f7202a2700765a431a4c430a04e90b0610ee520320581429042105c3c04104101882a858f0286b720205000c86a528, difficulty: 2, number: 40902315, gas_limit: 140000000, gas_used: 13157691, timestamp:
 1722273732, mix_hash: 0x0000000000000000000000000000000000000000000000000000000000000000, nonce: 0, base_fee_per_gas: Some(0), blob_gas_used: Some(0), excess_blob_gas: Some(0), parent_beacon_block_root: None, requests_root: None, extr
a_data: 0xd98301040b846765746889676f312e32312e3131856c696e7578000048fa7b051b44d76f23532f261ec0b3d9e9542fbef5d77fabc09005a16f9251da58f049d129d96f2d0d77fcea58a047707eb95ca92377bf296a348612734d6adfaaa8bdaa01 } }","error":"mismatched paren
t hash: got 0xa9a38fdb6af48eb647288d082a187b039d84011c237085f785af951eef0ff2eb, expected 0x1a9c657d1cd6981467912fe327f3c4131f3a68c2e03d13fb1b1827cc6daada39"},"target":"sync::pipeline"}
{"timestamp":"2024-07-29T17:32:15.331709Z","level":"INFO","fields":{"message":"Starting unwind","from":"40902314","to":"40902311","bad_block":"Some(40902314)"},"target":"sync::pipeline","span":{"stage":"Finish","name":"Unwinding"},"spa
ns":[{"stage":"Finish","name":"Unwinding"}]}
{"timestamp":"2024-07-29T17:32:15.331745Z","level":"INFO","fields":{"message":"Stage unwound","stage":"Finish","unwind_to":40902311,"progress":40902311,"done":true},"target":"sync::pipeline","span":{"stage":"Finish","name":"Unwinding"}
,"spans":[{"stage":"Finish","name":"Unwinding"}]}
{"timestamp":"2024-07-29T17:32:15

... stage unwind to 40902311...

{"timestamp":"2024-07-29T17:32:15.948199Z","level":"DEBUG","fields":{"message":"Polled next hook","hook":"StaticFile","result":"PolledHook { name: \"StaticFile\", event: Started, db_access_level: ReadOnly }"},"target":"consensus::engin
e::hooks"}
{"timestamp":"2024-07-29T17:32:15.948216Z","level":"DEBUG","fields":{"message":"Next hook is not ready","hook":"Prune"},"target":"consensus::engine::hooks"}
{"timestamp":"2024-07-29T17:32:15.948227Z","level":"DEBUG","fields":{"message":"StaticFileProducer started","targets":"StaticFileTargets { headers: Some(40902312..=40902312), receipts: Some(40902312..=40902312), transactions: Some(4090
2312..=40902312), sidecars: Some(40902312..=40902312) }"},"target":"static_file"}
{"timestamp":"2024-07-29T17:32:15.948265Z","level":"INFO","fields":{"message":"Static File Producer started","targets":"StaticFileTargets { headers: Some(40902312..=40902312), receipts: Some(40902312..=40902312), transactions: Some(409
02312..=40902312), sidecars: Some(40902312..=40902312) }"},"target":"reth_node_events::node"}
{"timestamp":"2024-07-29T17:32:15.948291Z","level":"DEBUG","fields":{"message":"StaticFileProducer segment","segment":"Transactions","block_range":"40902312..=40902312"},"target":"static_file"}
{"timestamp":"2024-07-29T17:32:15.948310Z","level":"DEBUG","fields":{"message":"StaticFileProducer segment","segment":"Receipts","block_range":"40902312..=40902312"},"target":"static_file"}
{"timestamp":"2024-07-29T17:32:15.948325Z","level":"DEBUG","fields":{"message":"StaticFileProducer segment","segment":"Headers","block_range":"40902312..=40902312"},"target":"static_file"}
{"timestamp":"2024-07-29T17:32:15.948356Z","level":"DEBUG","fields":{"message":"Finished StaticFileProducer segment","segment":"Headers","block_range":"40902312..=40902312","elapsed":"16.033µs"},"target":"static_file"}
{"timestamp":"2024-07-29T17:32:16.215853Z","level":"INFO","fields":{"message":"Status","connected_peers":98,"freelist":"48690580","stage":"Headers","checkpoint":40902314,"target":"40902311","stage_progress":"100.00%"},"target":"reth::c
li"}
... next stage sync...
{"timestamp":"2024-07-29T17:32:18.957360Z","level":"DEBUG","fields":{"message":"Commencing sync","tip":"Hash(0x73fe19ab138fa639e1af9700264af7912aec1ed3db4b2528e862e8c0ef7175bb)","head":"0x0e766c80ee469f28143f761b7e28fc2c3f169d39e580feef94b25183bc618582"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.957406Z","level":"INFO","fields":{"message":"Received headers","total":206,"from_block":40902517,"to_block":40902312},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.957743Z","level":"INFO","fields":{"message":"Executing stage","pipeline_stages":"1/12","stage":"Headers","checkpoint":"40902311","target":"None"},"target":"reth_node_events::node"}
{"timestamp":"2024-07-29T17:32:18.957748Z","level":"INFO","fields":{"message":"Writing headers","total":206},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.958359Z","level":"INFO","fields":{"message":"Writing headers","progress":"9.71%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.958752Z","level":"INFO","fields":{"message":"Writing headers","progress":"19.42%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.958880Z","level":"INFO","fields":{"message":"Writing headers","progress":"29.13%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.958996Z","level":"INFO","fields":{"message":"Writing headers","progress":"38.83%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.959123Z","level":"INFO","fields":{"message":"Writing headers","progress":"48.54%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.959242Z","level":"INFO","fields":{"message":"Writing headers","progress":"58.25%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.959357Z","level":"INFO","fields":{"message":"Writing headers","progress":"67.96%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.959471Z","level":"INFO","fields":{"message":"Writing headers","progress":"77.67%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.959581Z","level":"INFO","fields":{"message":"Writing headers","progress":"87.38%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.959696Z","level":"INFO","fields":{"message":"Writing headers","progress":"97.09%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.959735Z","level":"INFO","fields":{"message":"Writing headers hash index","total":206},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.961024Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"9.71%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.961591Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"19.42%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.962182Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"29.13%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.962743Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"38.83%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.963334Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"48.54%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.963916Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"58.25%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.964439Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"67.96%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.965036Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"77.67%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.965590Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"87.38%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.966193Z","level":"INFO","fields":{"message":"Writing headers hash index","progress":"97.09%"},"target":"sync::stages::headers"}
{"timestamp":"2024-07-29T17:32:18.966611Z","level":"INFO","fields":{"message":"Finished stage","pipeline_stages":"1/12","stage":"Headers","checkpoint":"40902517","target":"None","stage_progress":"100.00%"},"target":"reth_node_events::node"}
{"timestamp":"2024-07-29T17:32:18.967088Z","level":"DEBUG","fields":{"message":"Commit","segment":"Receipts","path":"\"/root/.local/share/reth/bsc/static_files/static_file_receipts_40500000_40999999\"","duration":"508.625µs"},"target":"provider::static_file"}
{"timestamp":"2024-07-29T17:32:18.967938Z","level":"DEBUG","fields":{"message":"Commit","segment":"Headers","path":"\"/root/.local/share/reth/bsc/static_files/static_file_headers_40500000_40999999\"","duration":"700.435µs"},"target":"provider::static_file"}
{"timestamp":"2024-07-29T17:32:18.968523Z","level":"DEBUG","fields":{"message":"Commit","segment":"Transactions","path":"\"/root/.local/share/reth/bsc/static_files/static_file_transactions_40500000_40999999\"","duration":"437.413µs"},"target":"provider::static_file"}
{"timestamp":"2024-07-29T17:32:18.970803Z","level":"DEBUG","fields":{"message":"Commit","total_duration":"2.162548ms","commit_latency":"Some(CommitLatency(MDBX_commit_latency { preparation: 0, gc_wallclock: 5, audit: 0, write: 0, sync: 133, ending: 0, whole: 139, gc_cputime: 0, gc_prof: MDBX_commit_latency__bindgen_ty_1 { wloops: 0, coalescences: 0, wipes: 0, flushes: 0, kicks: 0, work_counter: 0, work_rtime_monotonic: 0, work_xtime_cpu: 0, work_rsteps: 0, work_xpages: 0, work_majflt: 0, self_counter: 0, self_rtime_monotonic: 0, self_xtime_cpu: 0, self_rsteps: 0, self_xpages: 0, self_majflt: 0 } }))","is_read_only":false},"target":"storage::db::mdbx"}
{"timestamp":"2024-07-29T17:32:18.970893Z","level":"INFO","fields":{"message":"Preparing stage","pipeline_stages":"2/12","stage":"Bodies","checkpoint":"40902311","target":"40902517"},"target":"reth_node_events::node"}
{"timestamp":"2024-07-29T17:32:18.970903Z","level":"INFO","fields":{"message":"Downloading bodies","count":206,"range":"40902312..=40902517"},"target":"downloaders::bodies"}
{"timestamp":"2024-07-29T17:32:19.391238Z","level":"INFO","fields":{"message":"Executing stage","pipeline_stages":"2/12","stage":"Bodies","checkpoint":"40902311","target":"40902517"},"target":"reth_node_events::node"}
{"timestamp":"2024-07-29T17:32:19.391241Z","level":"DEBUG","fields":{"message":"Commencing sync","stage_progress":40902312,"target":40902517,"start_tx_id":5995551671},"target":"sync::stages::bodies"}
{"timestamp":"2024-07-29T17:32:19.395103Z","level":"ERROR","fields":{"message":"Stage encountered a fatal error: database integrity error occurred: trying to append data to Transactions as block #40902312 but expected block #40902313","stage":"Bodies"},"target":"sync::pipeline"}
{"timestamp":"2024-07-29T17:32:19.395441Z","level":"ERROR","fields":{"message":"shutting down due to error"},"target":"reth::cli"}
```
When stage sync detects that the hash is incorrect, it will perform a rollback.
<img width="1373" alt="image" src="https://github.com/user-attachments/assets/2f5867a7-6245-4dc0-87d7-e7e120399eb7">
At this time, three blocks will be forced to be rolled back.

But the finalized block of bsc is relatively early.
Will cause a rollback to the state before the finalized block.

However, the finalized hash tag of chain_state will not be rolled back.

As a result, the static file still increments the index based on the finalized hash.

In the end, the static file index cannot match the next stage sync block chase.


### Example

n/a

### Changes

Notable changes: 
* parlia engine
* engine hook(static file)

### Potential Impacts
* no
