### PR TITLE
fix: snapshot incompatibility issue

### DIFF
--- a/crates/bsc/consensus/src/lib.rs
+++ b/crates/bsc/consensus/src/lib.rs
@@ -323,7 +323,8 @@ impl Parlia {
         }
 
         let mut rng = if self.chain_spec.is_bohr_active_at_timestamp(header.timestamp) {
-            RngSource::new(header.number as i64 / snap.turn_length as i64)
+            let turn_length = snap.turn_length.unwrap_or(DEFAULT_TURN_LENGTH);
+            RngSource::new(header.number as i64 / turn_length as i64)
         } else {
             RngSource::new(snap.block_number as i64)
         };

--- a/crates/bsc/evm/src/execute.rs
+++ b/crates/bsc/evm/src/execute.rs
@@ -869,7 +869,7 @@ where
 
         // the old snapshots don't have turn length, make sure we initialize it with default
         // before accessing it
-        if snap.turn_length.is_none() {
+        if snap.turn_length.is_none() || snap.turn_length == Some(0) {
             snap.turn_length = Some(DEFAULT_TURN_LENGTH);
         }
 

--- a/crates/bsc/evm/src/execute.rs
+++ b/crates/bsc/evm/src/execute.rs
@@ -869,8 +869,8 @@ where
 
         // the old snapshots don't have turn length, make sure we initialize it with default
         // before accessing it
-        if snap.turn_length == 0 {
-            snap.turn_length = DEFAULT_TURN_LENGTH;
+        if snap.turn_length.is_none() {
+            snap.turn_length = Some(DEFAULT_TURN_LENGTH);
         }
 
         // apply skip headers

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -416,7 +416,7 @@ mod tests {
             validators_map: HashMap::new(),
             recent_proposers: BTreeMap::new(),
             vote_data: VoteData::default(),
-            turn_length: DEFAULT_TURN_LENGTH,
+            turn_length: Some(DEFAULT_TURN_LENGTH),
         };
         snap.validators_map.insert(
             snap.validators[0],


### PR DESCRIPTION
### Description

fix snapshot incompatibility issue

### Rationale
fix the bug after merged #86.
The old snapshot can't be read because of the incompatible struct

```
{"timestamp":"2024-08-05T10:22:12.709821Z","level":"WARN","fields":{"message":"Failed to insert downloaded block","err":"Failed to insert block (hash=0xf037acb25c7a81cd261e441a9dfe177cd15821788b0e20a8b1135b743b00e13d, number=42710013, parent_hash=0x3dd2442edfb1222b27f2b3e5835174b2472e9d70cd759b15a65b7fdf3c314202): provider inner error: failed to decode a key from a table"},"target":"consensus::engine"}
```

### Example

n/a

### Changes

Notable changes: 
* parlia/snapshot

### Potential Impacts
* no
