### PR TITLE
feat: add fork time for Wright Hardfork of opBNB in testnet

### DIFF
--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -487,6 +487,7 @@ impl OptimismHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1715754600)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1715754600)),
             (Self::Haber.boxed(), ForkCondition::Timestamp(1717048800)),
+            (Self::Wright.boxed(), ForkCondition::Timestamp(1723701600)), // Aug-15-2024 06:00 AM +UTC
         ])
     }
 

--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -487,7 +487,7 @@ impl OptimismHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1715754600)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1715754600)),
             (Self::Haber.boxed(), ForkCondition::Timestamp(1717048800)),
-            (Self::Wright.boxed(), ForkCondition::Timestamp(1723701600)), // Aug-15-2024 06:00 AM +UTC
+            (Self::Wright.boxed(), ForkCondition::Timestamp(1723701600)),
         ])
     }
 


### PR DESCRIPTION
### Description

This pr will add fork time for the `Wright` Hadrfork of opBNB in testnet.

### Rationale

Add fork time for Wright Hardfork of opBNB in testnet

### Example

n/a

### Changes

Notable changes: 
* add fork time for Wright Hardfork of opBNB in testnet

### Potential Impacts
na
