### PR TITLE
feat: add fork time for Bohr Hardfork of BSC in testnet

### DIFF
--- a/crates/ethereum-forks/src/hardfork/bsc.rs
+++ b/crates/ethereum-forks/src/hardfork/bsc.rs
@@ -258,6 +258,7 @@ impl BscHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1713330442)),
             (Self::Haber.boxed(), ForkCondition::Timestamp(1716962820)),
             (Self::HaberFix.boxed(), ForkCondition::Timestamp(1719986788)),
+            (Self::Bohr.boxed(), ForkCondition::Timestamp(1724116996)),
         ])
     }
 


### PR DESCRIPTION
### Description

This pr will add fork time for Bohr Hardfork of BSC in testnet. The expected fork time is 2024-08-20 01:23:16 AM UTC.

### Rationale

Add fork time for Bohr Hardfork of BSC in testnet

### Example
na

### Changes

Notable changes: 
* add fork time for Bohr Hardfork of BSC in testnet

### Potential Impacts
na
