### PR TITLE
feat: add mainnet fork time for Wright upgrade

### DIFF
--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -455,6 +455,7 @@ impl OptimismHardfork {
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1718871600)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1718871600)),
             (Self::Haber.boxed(), ForkCondition::Timestamp(1718872200)),
+            (Self::Wright.boxed(), ForkCondition::Timestamp(1724738400)),
         ])
     }
 


### PR DESCRIPTION
### Description

Modify the configuration to add the activation time of the `Wright` hard fork on the Mainnet.
Activation time is  2024-08-27 06:00:00 AM UTC.

### Rationale

Add mainnet fork time for Wright upgrade

### Example

na
### Changes

Notable changes: 
* add mainnet fork time for Wright upgrade

### Potential Impacts
na
