### PR TITLE
fix: cannot find parent block during livesync

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -279,8 +279,8 @@ impl Command {
                 #[cfg(not(feature = "bsc"))]
                 let executor = block_executor!(provider_factory.chain_spec()).executor(db);
 
-                let BlockExecutionOutput { state, receipts, requests, .. } =
-                    executor.execute((&block_with_senders.clone().unseal(), U256::MAX).into())?;
+                let BlockExecutionOutput { state, receipts, requests, .. } = executor
+                    .execute((&block_with_senders.clone().unseal(), U256::MAX, None).into())?;
                 let execution_outcome = ExecutionOutcome::new(
                     state,
                     receipts.into(),

--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -145,6 +145,7 @@ impl Command {
                     .with_recovered_senders()
                     .ok_or(BlockValidationError::SenderRecoveryError)?,
                 merkle_block_td + block.difficulty,
+                None,
             )
                 .into(),
         )?;

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -153,7 +153,7 @@ impl Command {
                     provider_rw.static_file_provider().clone(),
                 ),
             ));
-            executor.execute_and_verify_one((&sealed_block.clone().unseal(), td).into())?;
+            executor.execute_and_verify_one((&sealed_block.clone().unseal(), td, None).into())?;
             executor.finalize().write_to_storage(&provider_rw, None, OriginalValuesKnown::Yes)?;
 
             let checkpoint = Some(StageCheckpoint::new(

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -15,7 +15,8 @@ use reth_evm::execute::{BlockExecutionOutput, BlockExecutorProvider, Executor};
 use reth_execution_errors::BlockExecutionError;
 use reth_execution_types::{Chain, ExecutionOutcome};
 use reth_primitives::{
-    BlockHash, BlockNumber, ForkBlock, GotExpected, SealedBlockWithSenders, SealedHeader, U256,
+    BlockHash, BlockNumber, ForkBlock, GotExpected, Header, SealedBlockWithSenders, SealedHeader,
+    B256, U256,
 };
 use reth_provider::{
     providers::{BundleStateProvider, ConsistentDbView},
@@ -25,7 +26,7 @@ use reth_revm::database::StateProviderDatabase;
 use reth_trie::updates::TrieUpdates;
 use reth_trie_parallel::parallel_root::ParallelStateRoot;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     ops::{Deref, DerefMut},
     time::Instant,
 };
@@ -92,6 +93,7 @@ impl AppendableChain {
         let (bundle_state, trie_updates) = Self::validate_and_execute(
             block.clone(),
             parent_header,
+            None,
             state_provider,
             externals,
             block_attachment,
@@ -138,6 +140,7 @@ impl AppendableChain {
         let (block_state, _) = Self::validate_and_execute(
             block.clone(),
             parent,
+            None,
             bundle_state_data,
             externals,
             BlockAttachment::HistoricalFork,
@@ -170,6 +173,7 @@ impl AppendableChain {
     fn validate_and_execute<EDP, DB, E>(
         block: SealedBlockWithSenders,
         parent_block: &SealedHeader,
+        ancestor_blocks: Option<&HashMap<B256, Header>>,
         bundle_state_data_provider: EDP,
         externals: &TreeExternals<DB, E>,
         block_attachment: BlockAttachment,
@@ -209,7 +213,7 @@ impl AppendableChain {
         let block_hash = block.hash();
         let block = block.unseal();
 
-        let state = executor.execute((&block, U256::MAX, Some(parent_block.header())).into())?;
+        let state = executor.execute((&block, U256::MAX, ancestor_blocks).into())?;
         let BlockExecutionOutput { state, receipts, requests, .. } = state;
         externals
             .consensus
@@ -285,6 +289,9 @@ impl AppendableChain {
     {
         let parent_block = self.chain.tip();
 
+        let ancestor_blocks =
+            self.headers().map(|h| return (h.hash() as B256, h.header().clone())).collect();
+
         let bundle_state_data = BundleStateDataRef {
             execution_outcome: self.execution_outcome(),
             sidechain_block_hashes: &side_chain_block_hashes,
@@ -294,7 +301,8 @@ impl AppendableChain {
 
         let (block_state, _) = Self::validate_and_execute(
             block.clone(),
-            &(parent_block.clone()),
+            parent_block,
+            Some(&ancestor_blocks),
             bundle_state_data,
             externals,
             block_attachment,

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -209,7 +209,7 @@ impl AppendableChain {
         let block_hash = block.hash();
         let block = block.unseal();
 
-        let state = executor.execute((&block, U256::MAX).into())?;
+        let state = executor.execute((&block, U256::MAX, Some(parent_block.header())).into())?;
         let BlockExecutionOutput { state, receipts, requests, .. } = state;
         externals
             .consensus

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -294,7 +294,7 @@ impl AppendableChain {
 
         let (block_state, _) = Self::validate_and_execute(
             block.clone(),
-            parent_block,
+            &(parent_block.clone()),
             bundle_state_data,
             externals,
             block_attachment,

--- a/crates/bsc/engine/src/lib.rs
+++ b/crates/bsc/engine/src/lib.rs
@@ -79,7 +79,7 @@ where
         let mut safe_hash = None;
         let snapshot_reader =
             SnapshotReader::new(Arc::new(parlia_provider), Arc::new(parlia.clone()));
-        let snapshot_result = snapshot_reader.snapshot(&latest_header, None);
+        let snapshot_result = snapshot_reader.snapshot(&latest_header, None, None);
         if snapshot_result.is_ok() {
             let snap = snapshot_result.unwrap();
             finalized_hash = Some(snap.vote_data.source_hash);

--- a/crates/bsc/engine/src/lib.rs
+++ b/crates/bsc/engine/src/lib.rs
@@ -79,7 +79,7 @@ where
         let mut safe_hash = None;
         let snapshot_reader =
             SnapshotReader::new(Arc::new(parlia_provider), Arc::new(parlia.clone()));
-        let snapshot_result = snapshot_reader.snapshot(&latest_header, None, None);
+        let snapshot_result = snapshot_reader.snapshot(&latest_header, None);
         if snapshot_result.is_ok() {
             let snap = snapshot_result.unwrap();
             finalized_hash = Some(snap.vote_data.source_hash);

--- a/crates/bsc/engine/src/task.rs
+++ b/crates/bsc/engine/src/task.rs
@@ -486,7 +486,7 @@ impl<
                             ForkChoiceMessage::NewHeader(event) => {
                                 let new_header = event.local_header;
 
-                                let snap = match snapshot_reader.snapshot(&new_header, None, None) {
+                                let snap = match snapshot_reader.snapshot(&new_header, None) {
                                     Ok(snap) => snap,
                                     Err(err) => {
                                         error!(target: "consensus::parlia", %err, "Snapshot not found");

--- a/crates/bsc/engine/src/task.rs
+++ b/crates/bsc/engine/src/task.rs
@@ -61,7 +61,7 @@ pub(crate) struct ParliaEngineTask<
 > {
     /// The configured chain spec
     chain_spec: Arc<ChainSpec>,
-    /// The coneensus instance
+    /// The consensus instance
     consensus: Parlia,
     /// The provider used to read the block and header from the inserted chain
     provider: Provider,
@@ -486,7 +486,7 @@ impl<
                             ForkChoiceMessage::NewHeader(event) => {
                                 let new_header = event.local_header;
 
-                                let snap = match snapshot_reader.snapshot(&new_header, None) {
+                                let snap = match snapshot_reader.snapshot(&new_header, None, None) {
                                     Ok(snap) => snap,
                                     Err(err) => {
                                         error!(target: "consensus::parlia", %err, "Snapshot not found");

--- a/crates/bsc/evm/src/execute.rs
+++ b/crates/bsc/evm/src/execute.rs
@@ -393,15 +393,16 @@ where
         block_hash: B256,
         ancestor: Option<&HashMap<B256, Header>>,
     ) -> Result<Header, BlockExecutionError> {
-        let header = if let Some(m) = ancestor { m.get(&block_hash) } else { None };
-        match header {
-            Some(h) => Ok(h.clone()),
-            None => self
-                .provider
-                .header(&block_hash)
-                .map_err(|err| BscBlockExecutionError::ProviderInnerError { error: err.into() })?
-                .ok_or_else(|| BscBlockExecutionError::UnknownHeader { block_hash }.into()),
-        }
+        ancestor
+            .and_then(|m| m.get(&block_hash).cloned())
+            .or_else(|| {
+                self.provider
+                    .header(&block_hash)
+                    .map_err(|err| BscBlockExecutionError::ProviderInnerError { error: err.into() })
+                    .ok()
+                    .flatten()
+            })
+            .ok_or_else(|| BscBlockExecutionError::UnknownHeader { block_hash }.into())
     }
 
     /// Upgrade system contracts based on the hardfork rules.
@@ -938,15 +939,16 @@ where
         block_hash: B256,
         ancestor: Option<&HashMap<B256, Header>>,
     ) -> Result<Header, BlockExecutionError> {
-        let header = if let Some(m) = ancestor { m.get(&block_hash) } else { None };
-        match header {
-            Some(h) => Ok(h.clone()),
-            None => self
-                .provider
-                .header(&block_hash)
-                .map_err(|err| BscBlockExecutionError::ProviderInnerError { error: err.into() })?
-                .ok_or_else(|| BscBlockExecutionError::UnknownHeader { block_hash }.into()),
-        }
+        ancestor
+            .and_then(|m| m.get(&block_hash).cloned())
+            .or_else(|| {
+                self.provider
+                    .header(&block_hash)
+                    .map_err(|err| BscBlockExecutionError::ProviderInnerError { error: err.into() })
+                    .ok()
+                    .flatten()
+            })
+            .ok_or_else(|| BscBlockExecutionError::UnknownHeader { block_hash }.into())
     }
 
     fn find_ancient_header(

--- a/crates/bsc/evm/src/execute.rs
+++ b/crates/bsc/evm/src/execute.rs
@@ -864,11 +864,14 @@ where
                     block_hash = header.parent_hash;
                     header = h.clone();
                 }
-            } else if let Ok(h) = self.get_header_by_hash(header.parent_hash) {
-                found = true;
-                block_number = h.number;
-                block_hash = header.parent_hash;
-                header = h;
+            }
+            if !found {
+                if let Ok(h) = self.get_header_by_hash(header.parent_hash) {
+                    found = true;
+                    block_number = h.number;
+                    block_hash = header.parent_hash;
+                    header = h;
+                }
             }
             if !found {
                 return Err(

--- a/crates/bsc/evm/src/post_execution.rs
+++ b/crates/bsc/evm/src/post_execution.rs
@@ -456,7 +456,7 @@ where
         let justified_header = self.get_header_by_hash(attestation.data.target_hash)?;
         let parent = self.get_header_by_hash(justified_header.parent_hash)?;
         let snapshot_reader = SnapshotReader::new(self.provider.clone(), self.parlia.clone());
-        let snapshot = &(snapshot_reader.snapshot(&parent, None)?);
+        let snapshot = &(snapshot_reader.snapshot(&parent, None, None)?);
         let validators = &snapshot.validators;
         let validators_bit_set = BitSet::from_u64(attestation.vote_address_set);
 

--- a/crates/bsc/evm/src/post_execution.rs
+++ b/crates/bsc/evm/src/post_execution.rs
@@ -12,7 +12,7 @@ use reth_primitives::{
     hex,
     parlia::{Snapshot, VoteAddress, VoteAttestation},
     system_contracts::SYSTEM_REWARD_CONTRACT,
-    Address, BlockWithSenders, GotExpected, Header, Receipt, TransactionSigned, U256,
+    Address, BlockWithSenders, GotExpected, Header, Receipt, TransactionSigned, B256, U256,
 };
 use reth_provider::ParliaProvider;
 use reth_revm::bsc::SYSTEM_ADDRESS;
@@ -41,6 +41,7 @@ where
         &mut self,
         block: &BlockWithSenders,
         parent: &Header,
+        ancestor: Option<&HashMap<B256, Header>>,
         snap: &Snapshot,
         post_execution_input: PostExecutionInput,
         system_txs: &mut Vec<TransactionSigned>,
@@ -107,6 +108,7 @@ where
         if self.chain_spec().is_plato_active_at_block(number) {
             self.distribute_finality_reward(
                 header,
+                ancestor,
                 system_txs,
                 receipts,
                 cumulative_gas_used,
@@ -375,6 +377,7 @@ where
     fn distribute_finality_reward(
         &mut self,
         header: &Header,
+        ancestor: Option<&HashMap<B256, Header>>,
         system_txs: &mut Vec<TransactionSigned>,
         receipts: &mut Vec<Receipt>,
         cumulative_gas_used: &mut u64,
@@ -391,14 +394,14 @@ where
         let end = header.number;
         let mut target_hash = header.parent_hash;
         for _ in (start..end).rev() {
-            let header = &(self.get_header_by_hash(target_hash)?);
+            let header = &(self.get_header_by_hash(target_hash, ancestor)?);
 
             if let Some(attestation) =
                 self.parlia().get_vote_attestation_from_header(header).map_err(|err| {
                     BscBlockExecutionError::ParliaConsensusInnerError { error: err.into() }
                 })?
             {
-                self.process_attestation(&attestation, header, &mut accumulated_weights)?;
+                self.process_attestation(&attestation, header, ancestor, &mut accumulated_weights)?;
             }
 
             target_hash = header.parent_hash;
@@ -451,10 +454,11 @@ where
         &self,
         attestation: &VoteAttestation,
         parent_header: &Header,
+        ancestor: Option<&HashMap<B256, Header>>,
         accumulated_weights: &mut HashMap<Address, U256>,
     ) -> Result<(), BlockExecutionError> {
-        let justified_header = self.get_header_by_hash(attestation.data.target_hash)?;
-        let parent = self.get_header_by_hash(justified_header.parent_hash)?;
+        let justified_header = self.get_header_by_hash(attestation.data.target_hash, ancestor)?;
+        let parent = self.get_header_by_hash(justified_header.parent_hash, ancestor)?;
         let snapshot_reader = SnapshotReader::new(self.provider.clone(), self.parlia.clone());
         let snapshot = &(snapshot_reader.snapshot(&parent, None)?);
         let validators = &snapshot.validators;

--- a/crates/bsc/evm/src/post_execution.rs
+++ b/crates/bsc/evm/src/post_execution.rs
@@ -456,7 +456,7 @@ where
         let justified_header = self.get_header_by_hash(attestation.data.target_hash)?;
         let parent = self.get_header_by_hash(justified_header.parent_hash)?;
         let snapshot_reader = SnapshotReader::new(self.provider.clone(), self.parlia.clone());
-        let snapshot = &(snapshot_reader.snapshot(&parent, None, None)?);
+        let snapshot = &(snapshot_reader.snapshot(&parent, None)?);
         let validators = &snapshot.validators;
         let validators_bit_set = BitSet::from_u64(attestation.vote_address_set);
 

--- a/crates/bsc/evm/src/pre_execution.rs
+++ b/crates/bsc/evm/src/pre_execution.rs
@@ -122,7 +122,7 @@ where
             // Get the target_number - 1 block's snapshot.
             let pre_target_header = &(self.get_header_by_hash(parent.parent_hash)?);
             let snapshot_reader = SnapshotReader::new(self.provider.clone(), self.parlia.clone());
-            let snap = &(snapshot_reader.snapshot(pre_target_header, None, None)?);
+            let snap = &(snapshot_reader.snapshot(pre_target_header, None)?);
 
             // query bls keys from snapshot.
             let validators_count = snap.validators.len();

--- a/crates/bsc/evm/src/pre_execution.rs
+++ b/crates/bsc/evm/src/pre_execution.rs
@@ -122,7 +122,7 @@ where
             // Get the target_number - 1 block's snapshot.
             let pre_target_header = &(self.get_header_by_hash(parent.parent_hash)?);
             let snapshot_reader = SnapshotReader::new(self.provider.clone(), self.parlia.clone());
-            let snap = &(snapshot_reader.snapshot(pre_target_header, None)?);
+            let snap = &(snapshot_reader.snapshot(pre_target_header, None, None)?);
 
             // query bls keys from snapshot.
             let validators_count = snap.validators.len();

--- a/crates/consensus/auto-seal/src/lib.rs
+++ b/crates/consensus/auto-seal/src/lib.rs
@@ -388,7 +388,7 @@ impl StorageInner {
             requests: block_execution_requests,
             gas_used,
             ..
-        } = executor.executor(&mut db).execute((&block, U256::ZERO).into())?;
+        } = executor.executor(&mut db).execute((&block, U256::ZERO, None).into())?;
         let execution_outcome = ExecutionOutcome::new(
             state,
             receipts.into(),

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -658,7 +658,7 @@ where
         let block_number = block.number;
         let block_hash = block.hash();
         let block = block.unseal();
-        let output = executor.execute((&block, U256::MAX).into()).unwrap();
+        let output = executor.execute((&block, U256::MAX, None).into()).unwrap();
         self.consensus.validate_block_post_execution(
             &block,
             PostExecutionInput::new(&output.receipts, &output.requests),

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -365,7 +365,7 @@ where
     EvmConfig: ConfigureEvm,
     DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
 {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
@@ -375,7 +375,7 @@ where
     ///
     /// Returns an error if the block could not be executed or failed verification.
     fn execute(mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
-        let BlockExecutionInput { block, total_difficulty } = input;
+        let BlockExecutionInput { block, total_difficulty, .. } = input;
         let EthExecuteOutput { receipts, requests, gas_used } =
             self.execute_without_verification(block, total_difficulty)?;
 
@@ -419,12 +419,12 @@ where
     EvmConfig: ConfigureEvm,
     DB: Database<Error: Into<ProviderError> + Display>,
 {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = ExecutionOutcome;
     type Error = BlockExecutionError;
 
     fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {
-        let BlockExecutionInput { block, total_difficulty } = input;
+        let BlockExecutionInput { block, total_difficulty, .. } = input;
         let EthExecuteOutput { receipts, requests, gas_used: _ } =
             self.executor.execute_without_verification(block, total_difficulty)?;
 

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -567,6 +567,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -666,6 +667,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -720,6 +722,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -765,6 +768,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -793,6 +797,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -853,6 +858,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -924,6 +930,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -975,6 +982,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -1033,6 +1041,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -1097,6 +1106,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -1152,6 +1162,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -1192,6 +1203,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -1235,6 +1247,7 @@ mod tests {
                         senders: vec![],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -1325,6 +1338,7 @@ mod tests {
                     .with_recovered_senders()
                     .unwrap(),
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -1414,6 +1428,7 @@ mod tests {
                 .with_recovered_senders()
                 .unwrap(),
                 U256::ZERO,
+                None,
             )
                 .into(),
         );

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -7,7 +7,7 @@ use crate::execute::{
 };
 use reth_execution_errors::BlockExecutionError;
 use reth_execution_types::ExecutionOutcome;
-use reth_primitives::{BlockNumber, BlockWithSenders, Receipt};
+use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
 use revm_primitives::db::Database;
@@ -51,19 +51,19 @@ impl<A, B, DB> Executor<DB> for Either<A, B>
 where
     A: for<'a> Executor<
         DB,
-        Input<'a> = BlockExecutionInput<'a, BlockWithSenders>,
+        Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>,
         Output = BlockExecutionOutput<Receipt>,
         Error = BlockExecutionError,
     >,
     B: for<'a> Executor<
         DB,
-        Input<'a> = BlockExecutionInput<'a, BlockWithSenders>,
+        Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>,
         Output = BlockExecutionOutput<Receipt>,
         Error = BlockExecutionError,
     >,
     DB: Database<Error: Into<ProviderError> + Display>,
 {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
@@ -79,19 +79,19 @@ impl<A, B, DB> BatchExecutor<DB> for Either<A, B>
 where
     A: for<'a> BatchExecutor<
         DB,
-        Input<'a> = BlockExecutionInput<'a, BlockWithSenders>,
+        Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>,
         Output = ExecutionOutcome,
         Error = BlockExecutionError,
     >,
     B: for<'a> BatchExecutor<
         DB,
-        Input<'a> = BlockExecutionInput<'a, BlockWithSenders>,
+        Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>,
         Output = ExecutionOutcome,
         Error = BlockExecutionError,
     >,
     DB: Database<Error: Into<ProviderError> + Display>,
 {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = ExecutionOutcome;
     type Error = BlockExecutionError;
 

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -127,8 +127,8 @@ pub struct BlockExecutionInput<'a, Block, Header> {
     pub block: &'a Block,
     /// The total difficulty of the block.
     pub total_difficulty: U256,
-    /// The header of the block's parent
-    pub parent_header: Option<&'a HashMap<B256, Header>>,
+    /// The headers of the block's ancestor
+    pub ancestor_headers: Option<&'a HashMap<B256, Header>>,
 }
 
 impl<'a, Block, Header> BlockExecutionInput<'a, Block, Header> {
@@ -136,9 +136,9 @@ impl<'a, Block, Header> BlockExecutionInput<'a, Block, Header> {
     pub const fn new(
         block: &'a Block,
         total_difficulty: U256,
-        parent_header: Option<&'a HashMap<B256, Header>>,
+        ancestor_headers: Option<&'a HashMap<B256, Header>>,
     ) -> Self {
-        Self { block, total_difficulty, parent_header }
+        Self { block, total_difficulty, ancestor_headers }
     }
 }
 
@@ -146,13 +146,13 @@ impl<'a, Block, Header> From<(&'a Block, U256, Option<&'a HashMap<B256, Header>>
     for BlockExecutionInput<'a, Block, Header>
 {
     fn from(
-        (block, total_difficulty, parent_header): (
+        (block, total_difficulty, ancestor_headers): (
             &'a Block,
             U256,
             Option<&'a HashMap<B256, Header>>,
         ),
     ) -> Self {
-        Self::new(block, total_difficulty, parent_header)
+        Self::new(block, total_difficulty, ancestor_headers)
     }
 }
 

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -2,7 +2,7 @@
 
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives::{
-    parlia::Snapshot, BlockNumber, BlockWithSenders, Header, Receipt, Request, U256,
+    parlia::Snapshot, BlockNumber, BlockWithSenders, Header, Receipt, Request, B256, U256,
 };
 use reth_prune_types::PruneModes;
 use revm::db::BundleState;
@@ -11,6 +11,7 @@ use std::fmt::Display;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use std::collections::HashMap;
 
 pub use reth_execution_errors::{BlockExecutionError, BlockValidationError};
 pub use reth_storage_errors::provider::ProviderError;
@@ -127,7 +128,7 @@ pub struct BlockExecutionInput<'a, Block, Header> {
     /// The total difficulty of the block.
     pub total_difficulty: U256,
     /// The header of the block's parent
-    pub parent_header: Option<&'a Header>,
+    pub parent_header: Option<&'a HashMap<B256, Header>>,
 }
 
 impl<'a, Block, Header> BlockExecutionInput<'a, Block, Header> {
@@ -135,17 +136,21 @@ impl<'a, Block, Header> BlockExecutionInput<'a, Block, Header> {
     pub const fn new(
         block: &'a Block,
         total_difficulty: U256,
-        parent_header: Option<&'a Header>,
+        parent_header: Option<&'a HashMap<B256, Header>>,
     ) -> Self {
         Self { block, total_difficulty, parent_header }
     }
 }
 
-impl<'a, Block, Header> From<(&'a Block, U256, Option<&'a Header>)>
+impl<'a, Block, Header> From<(&'a Block, U256, Option<&'a HashMap<B256, Header>>)>
     for BlockExecutionInput<'a, Block, Header>
 {
     fn from(
-        (block, total_difficulty, parent_header): (&'a Block, U256, Option<&'a Header>),
+        (block, total_difficulty, parent_header): (
+            &'a Block,
+            U256,
+            Option<&'a HashMap<B256, Header>>,
+        ),
     ) -> Self {
         Self::new(block, total_difficulty, parent_header)
     }

--- a/crates/evm/src/execute.rs
+++ b/crates/evm/src/execute.rs
@@ -227,7 +227,7 @@ mod tests {
     struct TestExecutor<DB>(PhantomData<DB>);
 
     impl<DB> Executor<DB> for TestExecutor<DB> {
-        type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+        type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
         type Output = BlockExecutionOutput<Receipt>;
         type Error = BlockExecutionError;
 
@@ -237,7 +237,7 @@ mod tests {
     }
 
     impl<DB> BatchExecutor<DB> for TestExecutor<DB> {
-        type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+        type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
         type Output = ExecutionOutcome;
         type Error = BlockExecutionError;
 
@@ -276,6 +276,6 @@ mod tests {
             requests: None,
         };
         let block = BlockWithSenders::new(block, Default::default()).unwrap();
-        let _ = executor.execute(BlockExecutionInput::new(&block, U256::ZERO));
+        let _ = executor.execute(BlockExecutionInput::new(&block, U256::ZERO, None));
     }
 }

--- a/crates/evm/src/noop.rs
+++ b/crates/evm/src/noop.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 
 use reth_execution_errors::BlockExecutionError;
 use reth_execution_types::ExecutionOutcome;
-use reth_primitives::{BlockNumber, BlockWithSenders, Receipt};
+use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
 use revm_primitives::db::Database;
@@ -41,7 +41,7 @@ impl BlockExecutorProvider for NoopBlockExecutorProvider {
 }
 
 impl<DB> Executor<DB> for NoopBlockExecutorProvider {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
@@ -51,7 +51,7 @@ impl<DB> Executor<DB> for NoopBlockExecutorProvider {
 }
 
 impl<DB> BatchExecutor<DB> for NoopBlockExecutorProvider {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = ExecutionOutcome;
     type Error = BlockExecutionError;
 

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -6,7 +6,7 @@ use crate::execute::{
 use parking_lot::Mutex;
 use reth_execution_errors::BlockExecutionError;
 use reth_execution_types::ExecutionOutcome;
-use reth_primitives::{BlockNumber, BlockWithSenders, Receipt};
+use reth_primitives::{BlockNumber, BlockWithSenders, Header, Receipt};
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderError;
 use revm_primitives::db::Database;
@@ -46,7 +46,7 @@ impl BlockExecutorProvider for MockExecutorProvider {
 }
 
 impl<DB> Executor<DB> for MockExecutorProvider {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
@@ -64,7 +64,7 @@ impl<DB> Executor<DB> for MockExecutorProvider {
 }
 
 impl<DB> BatchExecutor<DB> for MockExecutorProvider {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = ExecutionOutcome;
     type Error = BlockExecutionError;
 

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -61,7 +61,7 @@ where
 
         trace!(target: "exex::backfill", number = block_number, txs = block_with_senders.block.body.len(), "Executing block");
 
-        let block_execution_output = executor.execute((&block_with_senders, td).into())?;
+        let block_execution_output = executor.execute((&block_with_senders, td, None).into())?;
 
         Ok((block_with_senders, block_execution_output))
     }

--- a/crates/exex/exex/src/backfill/mod.rs
+++ b/crates/exex/exex/src/backfill/mod.rs
@@ -290,7 +290,7 @@ mod tests {
             .execute(BlockExecutionInput {
                 block,
                 total_difficulty: U256::ZERO,
-                parent_header: None,
+                ancestor_headers: None,
             })?;
         block_execution_output.state.reverts.sort();
 

--- a/crates/exex/exex/src/backfill/mod.rs
+++ b/crates/exex/exex/src/backfill/mod.rs
@@ -287,7 +287,11 @@ mod tests {
                 provider.tx_ref(),
                 provider.static_file_provider().clone(),
             )))
-            .execute(BlockExecutionInput { block, total_difficulty: U256::ZERO })?;
+            .execute(BlockExecutionInput {
+                block,
+                total_difficulty: U256::ZERO,
+                parent_header: None,
+            })?;
         block_execution_output.state.reverts.sort();
 
         // Convert the block execution output to an execution outcome for committing to the database

--- a/crates/exex/exex/src/backfill/mod.rs
+++ b/crates/exex/exex/src/backfill/mod.rs
@@ -161,7 +161,7 @@ where
             }
             .with_senders_unchecked(senders);
 
-            executor.execute_and_verify_one((&block, td).into())?;
+            executor.execute_and_verify_one((&block, td, None).into())?;
             execution_duration += execute_start.elapsed();
 
             // TODO(alexey): report gas metrics using `block.header.gas_used`

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -606,6 +606,7 @@ mod tests {
                         senders: vec![addr, addr],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )
@@ -688,6 +689,7 @@ mod tests {
                         senders: vec![addr, addr],
                     },
                     U256::ZERO,
+                    None,
                 )
                     .into(),
             )

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -391,7 +391,7 @@ where
     EvmConfig: ConfigureEvm,
     DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
 {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = BlockExecutionOutput<Receipt>;
     type Error = BlockExecutionError;
 
@@ -403,7 +403,7 @@ where
     ///
     /// State changes are committed to the database.
     fn execute(mut self, input: Self::Input<'_>) -> Result<Self::Output, Self::Error> {
-        let BlockExecutionInput { block, total_difficulty } = input;
+        let BlockExecutionInput { block, total_difficulty, .. } = input;
         let (receipts, gas_used) = self.execute_without_verification(block, total_difficulty)?;
 
         // NOTE: we need to merge keep the reverts for the bundle retention
@@ -449,12 +449,12 @@ where
     EvmConfig: ConfigureEvm,
     DB: Database<Error: Into<ProviderError> + std::fmt::Display>,
 {
-    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders>;
+    type Input<'a> = BlockExecutionInput<'a, BlockWithSenders, Header>;
     type Output = ExecutionOutcome;
     type Error = BlockExecutionError;
 
     fn execute_and_verify_one(&mut self, input: Self::Input<'_>) -> Result<(), Self::Error> {
-        let BlockExecutionInput { block, total_difficulty } = input;
+        let BlockExecutionInput { block, total_difficulty, .. } = input;
         let (receipts, _gas_used) =
             self.executor.execute_without_verification(block, total_difficulty)?;
 

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -275,7 +275,7 @@ where
             // Execute the block
             let execute_start = Instant::now();
 
-            executor.execute_and_verify_one((&block, td).into()).map_err(|error| {
+            executor.execute_and_verify_one((&block, td, None).into()).map_err(|error| {
                 StageError::Block {
                     block: Box::new(block.header.clone().seal_slow()),
                     error: BlockErrorKind::Execution(error),


### PR DESCRIPTION
### Description

* Fix cannot find parent during livesync of BSC.
* Fix a dead loop issue in `snapshot` method (error is not handled previously).

### Rationale

During live sync of BSC, the executor will try to find the parent from the database, which may not have been committed yet.

<img width="577" alt="image" src="https://github.com/user-attachments/assets/baa40508-5634-40a5-a345-c0684a9d8720">


### Example

<img width="1446" alt="image" src="https://github.com/user-attachments/assets/8b8c32e0-9f0a-4218-804b-2fb2b833be00">

<img width="1697" alt="image" src="https://github.com/user-attachments/assets/33d6a2b3-a28f-4f64-bc3f-6016d71dc5a1">

<img width="1899" alt="image" src="https://github.com/user-attachments/assets/ce81487b-a85c-4e22-8bcc-55577f0fc8fc">

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
