### PR TITLE
feat: add canonical cache for live sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,7 +4202,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -6648,6 +6648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick_cache"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec932c60e6faf77dc6601ea149a23d821598b019b450bb1d98fe89c0301c0b61"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.14.5",
+ "parking_lot 0.12.3",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7269,9 +7281,11 @@ dependencies = [
  "alloy-genesis",
  "aquamarine",
  "assert_matches",
+ "lazy_static",
  "linked_hash_set",
  "metrics",
  "parking_lot 0.12.3",
+ "quick_cache",
  "reth-blockchain-tree-api",
  "reth-chainspec",
  "reth-consensus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,7 +4202,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8732,6 +8732,7 @@ dependencies = [
  "reth-auto-seal-consensus",
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
+ "reth-blockchain-tree",
  "reth-chainspec",
  "reth-consensus",
  "reth-db",

--- a/crates/blockchain-tree/Cargo.toml
+++ b/crates/blockchain-tree/Cargo.toml
@@ -38,6 +38,10 @@ tokio = { workspace = true, features = ["macros", "sync"] }
 reth-metrics = { workspace = true, features = ["common"] }
 metrics.workspace = true
 
+# cache
+quick_cache = "0.6.2"
+lazy_static = "1.4.0"
+
 # misc
 aquamarine.workspace = true
 linked_hash_set.workspace = true

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1,7 +1,7 @@
 //! Implementation of [`BlockchainTree`]
 
 use crate::{
-    canonical_cache::{apply_bundle_state, clear_accounts_and_storages},
+    canonical_cache::apply_bundle_state,
     metrics::{MakeCanonicalAction, MakeCanonicalDurationsRecorder, TreeMetrics},
     state::{BlockchainId, TreeState},
     AppendableChain, BlockIndices, BlockchainTreeConfig, ExecutionData, TreeExternals,
@@ -1343,9 +1343,6 @@ where
             .map_err(|e| CanonicalError::CanonicalRevert(e.to_string()))?;
 
         provider_rw.commit()?;
-
-        // clear global canonical cache
-        clear_accounts_and_storages();
 
         if blocks_and_execution.is_empty() {
             Ok(None)

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -1262,7 +1262,7 @@ where
         };
         recorder.record_relative(MakeCanonicalAction::RetrieveStateTrieUpdates);
 
-        let cloned_bundle = state.clone().bundle;
+        let cloned_bundle = state.bundle.clone();
         let provider_rw = self.externals.provider_factory.provider_rw()?;
         provider_rw
             .append_blocks_with_state(

--- a/crates/blockchain-tree/src/canonical_cache.rs
+++ b/crates/blockchain-tree/src/canonical_cache.rs
@@ -19,13 +19,14 @@ lazy_static! {
     pub static ref ACCOUNT_CACHE: Cache<Address, Account> = Cache::new(CACHE_SIZE);
 
     /// Contract cache
-    static ref CONTRACT_CACHE: Cache<B256, Bytecode> = Cache::new(CACHE_SIZE);
+    /// The size of contract is large and the hot contracts should be limited.
+    static ref CONTRACT_CACHE: Cache<B256, Bytecode> = Cache::new(CACHE_SIZE/10);
 
     /// Storage cache
     static ref STORAGE_CACHE: Cache<AddressStorageKey, StorageValue> = Cache::new(CACHE_SIZE*10);
 
     /// Block hash cache
-    static ref BLOCK_HASH_CACHE: Cache<u64, B256> = Cache::new(CACHE_SIZE);
+    static ref BLOCK_HASH_CACHE: Cache<u64, B256> = Cache::new(CACHE_SIZE/10);
 }
 
 /// Apply committed state to canonical cache.

--- a/crates/blockchain-tree/src/canonical_cache.rs
+++ b/crates/blockchain-tree/src/canonical_cache.rs
@@ -1,0 +1,231 @@
+use lazy_static::lazy_static;
+use quick_cache::sync::Cache;
+use reth_primitives::{Account, Address, BlockNumber, Bytecode, StorageKey, StorageValue, B256};
+use reth_provider::{
+    AccountReader, BlockHashReader, ExecutionDataProvider, StateProofProvider, StateProvider,
+    StateRootProvider,
+};
+use reth_revm::db::BundleState;
+use reth_storage_errors::provider::ProviderResult;
+use reth_trie::{updates::TrieUpdates, AccountProof, HashedPostState};
+
+/// The size of cache, counted by the number of accounts.
+const CACHE_SIZE: usize = 1000000;
+
+type AddressStorageKey = (Address, StorageKey);
+
+lazy_static! {
+    /// Account cache
+    pub static ref ACCOUNT_CACHE: Cache<Address, Account> = Cache::new(CACHE_SIZE);
+
+    /// Contract cache
+    static ref CONTRACT_CACHE: Cache<B256, Bytecode> = Cache::new(CACHE_SIZE);
+
+    /// Storage cache
+    static ref STORAGE_CACHE: Cache<AddressStorageKey, StorageValue> = Cache::new(CACHE_SIZE*10);
+
+    /// Block hash cache
+    static ref BLOCK_HASH_CACHE: Cache<u64, B256> = Cache::new(CACHE_SIZE);
+}
+
+/// Apply committed state to canonical cache.
+pub(crate) fn apply_bundle_state(bundle: BundleState) {
+    let change_set = bundle.into_plain_state(reth_provider::OriginalValuesKnown::Yes);
+
+    for (address, account_info) in &change_set.accounts {
+        match account_info {
+            None => {
+                ACCOUNT_CACHE.remove(address);
+            }
+            Some(acc) => {
+                ACCOUNT_CACHE.insert(
+                    *address,
+                    Account {
+                        nonce: acc.nonce,
+                        balance: acc.balance,
+                        bytecode_hash: Some(acc.code_hash),
+                    },
+                );
+            }
+        }
+    }
+
+    let mut to_wipe = false;
+    for storage in &change_set.storage {
+        if storage.wipe_storage {
+            to_wipe = true;
+            break;
+        } else {
+            for (k, v) in storage.storage.clone() {
+                STORAGE_CACHE.insert((storage.address, StorageKey::from(k)), v);
+            }
+        }
+    }
+    if to_wipe {
+        STORAGE_CACHE.clear();
+    }
+}
+
+/// Clear cached accounts and storages.
+pub fn clear_accounts_and_storages() {
+    ACCOUNT_CACHE.clear();
+    STORAGE_CACHE.clear();
+}
+
+#[derive(Debug)]
+pub(crate) struct CachedBundleStateProvider<SP: StateProvider, EDP: ExecutionDataProvider> {
+    /// The inner state provider.
+    pub(crate) state_provider: SP,
+    /// Block execution data.
+    pub(crate) block_execution_data_provider: EDP,
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> CachedBundleStateProvider<SP, EDP> {
+    /// Create new cached bundle state provider
+    pub(crate) const fn new(state_provider: SP, block_execution_data_provider: EDP) -> Self {
+        Self { state_provider, block_execution_data_provider }
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> BlockHashReader
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn block_hash(&self, block_number: BlockNumber) -> ProviderResult<Option<B256>> {
+        let block_hash = self.block_execution_data_provider.block_hash(block_number);
+        if block_hash.is_some() {
+            return Ok(block_hash)
+        }
+        if let Some(v) = BLOCK_HASH_CACHE.get(&block_number) {
+            return Ok(Some(v))
+        }
+        if let Some(value) = self.state_provider.block_hash(block_number)? {
+            BLOCK_HASH_CACHE.insert(block_number, value);
+            return Ok(Some(value))
+        }
+        Ok(None)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        _start: BlockNumber,
+        _end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        unimplemented!()
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> AccountReader
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
+        if let Some(account) =
+            self.block_execution_data_provider.execution_outcome().account(&address)
+        {
+            return Ok(account)
+        }
+        if let Some(v) = ACCOUNT_CACHE.get(&address) {
+            return Ok(Some(v))
+        }
+        if let Some(value) = self.state_provider.basic_account(address)? {
+            ACCOUNT_CACHE.insert(address, value);
+            return Ok(Some(value))
+        }
+        Ok(None)
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn state_root(&self, bundle_state: &BundleState) -> ProviderResult<B256> {
+        let mut state = self.block_execution_data_provider.execution_outcome().state().clone();
+        state.extend(bundle_state.clone());
+        self.state_provider.state_root(&state)
+    }
+
+    fn hashed_state_root(&self, hashed_state: &reth_trie::HashedPostState) -> ProviderResult<B256> {
+        let bundle_state = self.block_execution_data_provider.execution_outcome().state();
+        let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
+        state.extend(hashed_state.clone());
+        self.state_provider.hashed_state_root(&state)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        bundle_state: &BundleState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let mut state = self.block_execution_data_provider.execution_outcome().state().clone();
+        state.extend(bundle_state.clone());
+        self.state_provider.state_root_with_updates(&state)
+    }
+
+    fn hashed_state_root_with_updates(
+        &self,
+        hashed_state: &HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let bundle_state = self.block_execution_data_provider.execution_outcome().state();
+        let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
+        state.extend(hashed_state.clone());
+        self.state_provider.hashed_state_root_with_updates(&state)
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProofProvider
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn hashed_proof(
+        &self,
+        hashed_state: &HashedPostState,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        let bundle_state = self.block_execution_data_provider.execution_outcome().state();
+        let mut state = HashedPostState::from_bundle_state(&bundle_state.state);
+        state.extend(hashed_state.clone());
+        self.state_provider.hashed_proof(&state, address, slots)
+    }
+}
+
+impl<SP: StateProvider, EDP: ExecutionDataProvider> StateProvider
+    for CachedBundleStateProvider<SP, EDP>
+{
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let u256_storage_key = storage_key.into();
+        if let Some(value) = self
+            .block_execution_data_provider
+            .execution_outcome()
+            .storage(&account, u256_storage_key)
+        {
+            return Ok(Some(value))
+        }
+        let cache_key = (account, storage_key);
+        if let Some(v) = STORAGE_CACHE.get(&cache_key) {
+            return Ok(Some(v))
+        }
+        if let Some(value) = self.state_provider.storage(account, storage_key)? {
+            STORAGE_CACHE.insert(cache_key, value);
+            return Ok(Some(value))
+        }
+        Ok(None)
+    }
+
+    fn bytecode_by_hash(&self, code_hash: B256) -> ProviderResult<Option<Bytecode>> {
+        if let Some(bytecode) =
+            self.block_execution_data_provider.execution_outcome().bytecode(&code_hash)
+        {
+            return Ok(Some(bytecode))
+        }
+        if let Some(v) = CONTRACT_CACHE.get(&code_hash) {
+            return Ok(Some(v))
+        }
+        if let Some(value) = self.state_provider.bytecode_by_hash(code_hash)? {
+            CONTRACT_CACHE.insert(code_hash, value.clone());
+            return Ok(Some(value))
+        }
+        Ok(None)
+    }
+}

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -4,7 +4,10 @@
 //! blocks, as well as a list of the blocks the chain is composed of.
 
 use super::externals::TreeExternals;
-use crate::{canonical_cache::CachedBundleStateProvider, BundleStateDataRef};
+use crate::{
+    canonical_cache::{clear_accounts_and_storages, CachedBundleStateProvider},
+    BundleStateDataRef,
+};
 use reth_blockchain_tree_api::{
     error::{BlockchainTreeError, InsertBlockErrorKind},
     BlockAttachment, BlockValidationKind,
@@ -80,6 +83,12 @@ impl AppendableChain {
     {
         let execution_outcome = ExecutionOutcome::default();
         let empty = BTreeMap::new();
+
+        if block_attachment == BlockAttachment::HistoricalFork {
+            // The fork is a historical fork, the global canonical cache could be dirty.
+            // The case should be rare for bsc & op.
+            clear_accounts_and_storages();
+        }
 
         let state_provider = BundleStateDataRef {
             execution_outcome: &execution_outcome,

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -4,7 +4,7 @@
 //! blocks, as well as a list of the blocks the chain is composed of.
 
 use super::externals::TreeExternals;
-use crate::BundleStateDataRef;
+use crate::{canonical_cache::CachedBundleStateProvider, BundleStateDataRef};
 use reth_blockchain_tree_api::{
     error::{BlockchainTreeError, InsertBlockErrorKind},
     BlockAttachment, BlockValidationKind,
@@ -18,8 +18,7 @@ use reth_primitives::{
     BlockHash, BlockNumber, ForkBlock, GotExpected, SealedBlockWithSenders, SealedHeader, U256,
 };
 use reth_provider::{
-    providers::{BundleStateProvider, ConsistentDbView},
-    FullExecutionDataProvider, ProviderError, StateRootProvider,
+    providers::ConsistentDbView, FullExecutionDataProvider, ProviderError, StateRootProvider,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_trie::updates::TrieUpdates;
@@ -202,7 +201,7 @@ impl AppendableChain {
             .disable_long_read_transaction_safety()
             .state_provider_by_block_number(canonical_fork.number)?;
 
-        let provider = BundleStateProvider::new(state_provider, bundle_state_data_provider);
+        let provider = CachedBundleStateProvider::new(state_provider, bundle_state_data_provider);
 
         let db = StateProviderDatabase::new(&provider);
         let executor = externals.executor_factory.executor(db);

--- a/crates/blockchain-tree/src/lib.rs
+++ b/crates/blockchain-tree/src/lib.rs
@@ -56,4 +56,7 @@ pub mod noop;
 
 mod state;
 
+/// The global canonical cache for live sync.
+pub mod canonical_cache;
+
 use aquamarine as _;

--- a/crates/consensus/beacon/Cargo.toml
+++ b/crates/consensus/beacon/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 reth-chainspec.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-blockchain-tree-api.workspace = true
+reth-blockchain-tree.workspace = true
 reth-primitives.workspace = true
 reth-stages-api.workspace = true
 reth-errors.workspace = true

--- a/crates/consensus/beacon/src/engine/sync.rs
+++ b/crates/consensus/beacon/src/engine/sync.rs
@@ -6,6 +6,7 @@ use crate::{
     engine::metrics::EngineSyncMetrics, BeaconConsensusEngineEvent, ConsensusEngineLiveSyncProgress,
 };
 use futures::FutureExt;
+use reth_blockchain_tree::canonical_cache;
 #[cfg(feature = "bsc")]
 use reth_bsc_consensus::Parlia;
 use reth_chainspec::ChainSpec;
@@ -27,7 +28,7 @@ use std::{
     task::{ready, Context, Poll},
 };
 use tokio::sync::oneshot;
-use tracing::trace;
+use tracing::{debug, trace};
 
 /// Manages syncing under the control of the engine.
 ///
@@ -220,6 +221,11 @@ where
             // precaution to never sync to the zero hash
             return
         }
+        debug!(
+            target: "consensus::engine::sync",
+            "Clear global canonical cache."
+        );
+        canonical_cache::clear_accounts_and_storages();
         self.pending_pipeline_target = Some(target);
     }
 

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -38,7 +38,7 @@ reth-exex.workspace = true
 
 # misc
 eyre.workspace = true
-tokio = { workspace = true , features = ["sync"]}
+tokio = { workspace = true, features = ["sync"] }
 tokio-stream.workspace = true
 futures.workspace = true
 
@@ -49,6 +49,7 @@ reth-db.workspace = true
 reth-exex.workspace = true
 reth-node-api.workspace = true
 reth-node-core.workspace = true
+reth-blockchain-tree.workspace = true
 reth-e2e-test-utils.workspace = true
 alloy-primitives.workspace = true
 alloy-genesis.workspace = true

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -1,4 +1,5 @@
 use crate::utils::eth_payload_attributes;
+use reth::blockchain_tree::canonical_cache;
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::{setup, transaction::TransactionTestContext};
 use reth_node_ethereum::EthereumNode;
@@ -39,6 +40,10 @@ async fn can_sync() -> eyre::Result<()> {
 
     // only send forkchoice update to second node
     second_node.engine_api.update_forkchoice(block_hash, block_hash).await?;
+
+    // The canonical cache is static, which means that the two nodes will share the same cache.
+    // Need to clear the cache to advance the second node.
+    canonical_cache::clear_accounts_and_storages();
 
     // expect second node advanced via p2p gossip
     second_node.assert_new_block(tx_hash, block_hash, 1).await?;


### PR DESCRIPTION
### Description

Add cache layer to cache historical committed accounts & storages.

### Rationale

To improve the execution of live sync.

### Example

#### Test Result - Live sync 20K blocks on BSC, from 41413200 to 41433100.

Note: There are reboots before each tests, to make sure the test environment is clean.

* Metrics 1 - hit rate
<img width="759" alt="image" src="https://github.com/user-attachments/assets/4e466394-0dc6-43b4-b796-743d534c9a5c">

account hit rate (the l3 account in the figure): 36.2%

storage hit rate (the l3 storage in the figure): 43.3%

Note: l1 account & storage caches refer to the revm state cache.

* Metrics 2 - the execution time for every 100 blocks

<img width="877" alt="image" src="https://github.com/user-attachments/assets/d2382fb8-1c6f-400f-b85e-4a06e0b34373">

<img width="868" alt="image" src="https://github.com/user-attachments/assets/cbe9d649-fe07-4147-acff-5ddbc12bd21d">

The time decreases about 21% after steady. (due to reboot, at the beginning, the performance is bad for both). 

The time to apply bundle state to cache (update cache after db commit) is included for the cached version.

* Metrics 3 - the gas throughput for [41432701, 41433100]

<img width="963" alt="image" src="https://github.com/user-attachments/assets/9b5641a3-ee75-4167-bed3-6f313c487a0f">

The cached version is 356 Mgas/s for execution on avg, while the original version is 277 Mgas/s.

The gas throughput increases about 28%.  Why it is not aligned to the execution time?
- The avg Mgas/s is calculated from the log (each block has a log about it).
- The cached version introduces some extra cost for applying state to cache. This extra time is included in the Metrics 2.


### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
