### PR TITLE
fix: print CanonicalBlockAdded logs after committed db

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1734,14 +1734,6 @@ where
                     Ok(status) => {
                         match status {
                             InsertPayloadOk::Inserted(BlockStatus::Valid(_)) => {
-                                let elapsed = start.elapsed();
-                                let event_block = Arc::new(block);
-                                let event = BeaconConsensusEngineEvent::CanonicalBlockAdded(
-                                    event_block,
-                                    elapsed,
-                                );
-                                self.event_sender.notify(event);
-
                                 // block is connected to the canonical chain and is valid.
                                 // if it's not connected to current canonical head, the state root
                                 // has not been validated.
@@ -1759,6 +1751,14 @@ where
                                         )
                                     }
                                 }
+
+                                let elapsed = start.elapsed();
+                                let event_block = Arc::new(block);
+                                let event = BeaconConsensusEngineEvent::CanonicalBlockAdded(
+                                    event_block,
+                                    elapsed,
+                                );
+                                self.event_sender.notify(event);
                             }
                             InsertPayloadOk::Inserted(BlockStatus::Disconnected {
                                 head,


### PR DESCRIPTION
### Description

print CanonicalBlockAdded logs after committed db

### Rationale

n/a

### Example

n/a

### Changes

Notable changes: 
* no

### Potential Impacts
* no
