### PR TITLE
feat: add mainnet fork time for HaberFix and Bohr upgrade

### DIFF
--- a/crates/ethereum-forks/src/hardfork/bsc.rs
+++ b/crates/ethereum-forks/src/hardfork/bsc.rs
@@ -221,6 +221,8 @@ impl BscHardfork {
             (Self::FeynmanFix.boxed(), ForkCondition::Timestamp(1713419340)),
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1718863500)),
             (Self::Haber.boxed(), ForkCondition::Timestamp(1718863500)),
+            (Self::HaberFix.boxed(), ForkCondition::Timestamp(1727316120)),
+            (Self::Bohr.boxed(), ForkCondition::Timestamp(1727317200)),
         ])
     }
 


### PR DESCRIPTION
### Descriptions
`HaberFix` is a bugfix hard fork, which mainly enhances the network's stability in some corner cases, so we decide to support it along with `Bohr` hard fork on mainnet to avoid too frequent node upgrade.
The 2 hard fork will be enabled subsequently, i.e. `Bohr` will be a few minutes after `Haberfix`

The expected hard fork date:
- Mainnet-HaberFix: 2024-09-26 02:02:00 AM UTC
- Mainnet-Bohr:     2024-09-26 02:20:00 AM UTC

### Rationale
NA

### Example
NA

### Changes
NA
