### PR TITLE
fix: sidecars missing issue and empty validators election info issue

### DIFF
--- a/crates/bsc/consensus/src/feynman_fork.rs
+++ b/crates/bsc/consensus/src/feynman_fork.rs
@@ -35,7 +35,7 @@ impl PartialOrd for ValidatorElectionInfo {
 pub fn get_top_validators_by_voting_power(
     validators: Vec<ValidatorElectionInfo>,
     max_elected_validators: U256,
-) -> Option<ElectedValidators> {
+) -> ElectedValidators {
     let mut validator_heap: BinaryHeap<ValidatorElectionInfo> = BinaryHeap::new();
     for info in validators {
         if info.voting_power > U256::ZERO {
@@ -60,15 +60,11 @@ pub fn get_top_validators_by_voting_power(
         }
     }
 
-    if e_validators.is_empty() {
-        return None;
-    }
-
-    Some(ElectedValidators {
+    ElectedValidators {
         validators: e_validators,
         voting_powers: e_voting_powers,
         vote_addrs: e_vote_addrs,
-    })
+    }
 }
 
 #[cfg(test)]
@@ -207,13 +203,8 @@ mod tests {
         ];
 
         for (description, k, validators, expected) in test_cases {
-            let eligible_validators = if let Some(elected) =
-                get_top_validators_by_voting_power(validators, U256::from(k))
-            {
-                elected.validators
-            } else {
-                Vec::new()
-            };
+            let eligible_validators =
+                get_top_validators_by_voting_power(validators, U256::from(k)).validators;
 
             assert_eq!(eligible_validators.len(), expected.len(), "case: {}", description);
             for i in 0..expected.len() {

--- a/crates/bsc/evm/src/post_execution.rs
+++ b/crates/bsc/evm/src/post_execution.rs
@@ -429,8 +429,7 @@ where
         env: EnvWithHandlerCfg,
     ) -> Result<(), BlockExecutionError> {
         let ElectedValidators { validators, voting_powers, vote_addrs } =
-            get_top_validators_by_voting_power(validators_election_info, max_elected_validators)
-                .ok_or_else(|| BscBlockExecutionError::GetTopValidatorsFailed)?;
+            get_top_validators_by_voting_power(validators_election_info, max_elected_validators);
 
         self.transact_system_tx(
             self.parlia().update_validator_set_v2(validators, voting_powers, vote_addrs),

--- a/crates/prune/prune/src/segments/static_file/sidecars.rs
+++ b/crates/prune/prune/src/segments/static_file/sidecars.rs
@@ -100,7 +100,7 @@ mod tests {
         let db = TestStageDB::default();
         let mut rng = generators::rng();
 
-        let blocks = random_block_range(&mut rng, 1..=15, B256::ZERO, 0..1);
+        let blocks = random_block_range(&mut rng, 0..=15, B256::ZERO, 0..1);
         db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
 
         assert_eq!(db.table::<tables::Sidecars>().unwrap().len(), blocks.len());
@@ -154,12 +154,13 @@ mod tests {
             provider.commit().expect("commit");
 
             let last_pruned_block_number = to_block.min(
-                next_block_number_to_prune + input.limiter.deleted_entries_limit().unwrap() as u64,
+                next_block_number_to_prune +
+                    (input.limiter.deleted_entries_limit().unwrap() - 1) as u64,
             );
 
             assert_eq!(
                 db.table::<tables::Sidecars>().unwrap().len(),
-                blocks.len() - last_pruned_block_number as usize
+                blocks.len() - (last_pruned_block_number + 1) as usize
             );
             assert_eq!(
                 db.factory
@@ -179,6 +180,6 @@ mod tests {
             12,
             (PruneProgress::HasMoreData(PruneInterruptReason::DeletedEntriesLimitReached), 10),
         );
-        test_prune(12, (PruneProgress::Finished, 2));
+        test_prune(12, (PruneProgress::Finished, 3));
     }
 }


### PR DESCRIPTION
### Description

This pr is to fix 2 issues for bsc

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* write sidecars to file in `log_transactions`
* let `get_top_validators_by_voting_power` return empty vector rather than `None` 

### Potential Impacts
* add potential impacts for other components here
* ...
