### PR TITLE
fix: bsc snapshot issues

### DIFF
--- a/crates/bsc/evm/src/execute.rs
+++ b/crates/bsc/evm/src/execute.rs
@@ -928,9 +928,10 @@ where
                     self.parlia.chain_spec().is_bohr_active_at_timestamp(header.timestamp),
                 )
                 .ok_or_else(|| BscBlockExecutionError::ApplySnapshotFailed)?;
+
+            cache.put(snap.block_hash, snap.clone());
         }
 
-        cache.put(snap.block_hash, snap.clone());
         Ok(snap)
     }
 

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -97,6 +97,7 @@ impl Command {
                 tx.clear::<tables::StorageChangeSets>()?;
                 tx.clear::<tables::Bytecodes>()?;
                 tx.clear::<tables::Receipts>()?;
+                tx.clear::<tables::ParliaSnapshot>()?;
                 tx.put::<tables::StageCheckpoints>(
                     StageId::Execution.to_string(),
                     Default::default(),


### PR DESCRIPTION
### Description

This pr is to fix 3 issues related to bsc snapshot.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* clear `ParliaSnapshot` table when running drop cmd
* put snapshot into cache each time it's updated to avoid redundant calculations
* commit snapshot to database in live sync

### Potential Impacts
* add potential impacts for other components here
* ...
