### PR TITLE
feat: support importing blocks without merkle calculation

### DIFF
--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -51,9 +51,6 @@ pub struct Command {
     /// Defaults to `1000`.
     #[arg(long, default_value = "1000")]
     pub interval: u64,
-
-    #[arg(long)]
-    skip_state_root_validation: bool,
 }
 
 impl Command {
@@ -100,7 +97,7 @@ impl Command {
                     executor.clone(),
                     stage_conf.clone(),
                     prune_modes.clone(),
-                    self.skip_state_root_validation,
+                    self.env.performance_optimization.skip_state_root_validation,
                 )
                 .set(ExecutionStage::new(
                     executor,

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -53,7 +53,7 @@ pub struct Command {
     pub interval: u64,
 
     #[arg(long)]
-    disable_hashing_stages: bool,
+    skip_state_root_validation: bool,
 }
 
 impl Command {
@@ -100,7 +100,7 @@ impl Command {
                     executor.clone(),
                     stage_conf.clone(),
                     prune_modes.clone(),
-                    self.disable_hashing_stages,
+                    self.skip_state_root_validation,
                 )
                 .set(ExecutionStage::new(
                     executor,

--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -51,6 +51,9 @@ pub struct Command {
     /// Defaults to `1000`.
     #[arg(long, default_value = "1000")]
     pub interval: u64,
+
+    #[arg(long)]
+    disable_hashing_stages: bool,
 }
 
 impl Command {
@@ -97,6 +100,7 @@ impl Command {
                     executor.clone(),
                     stage_conf.clone(),
                     prune_modes.clone(),
+                    self.disable_hashing_stages,
                 )
                 .set(ExecutionStage::new(
                     executor,

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -180,7 +180,7 @@ where
     }
 
     /// Set the merkle root calculation to be disabled.
-    /// 
+    ///
     /// This is helpful when the merkle root is taking too long to calculate.
     pub fn disable_merkle_root_calculation(mut self) -> Self {
         self.disable_merkle_root_calculation = true;
@@ -1268,8 +1268,8 @@ where
                         .externals
                         .provider_factory
                         .provider()?
-                        // State root calculation can take a while, and we're sure no write transaction
-                        // will be open in parallel. See https://github.com/paradigmxyz/reth/issues/6168.
+                        // State root calculation can take a while, and we're sure no write
+                        // transaction will be open in parallel. See https://github.com/paradigmxyz/reth/issues/6168.
                         .disable_long_read_transaction_safety();
                     let (state_root, trie_updates) = StateRoot::from_tx(provider.tx_ref())
                         .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(

--- a/crates/blockchain-tree/src/blockchain_tree.rs
+++ b/crates/blockchain-tree/src/blockchain_tree.rs
@@ -182,7 +182,7 @@ where
     /// Set the merkle root calculation to be disabled.
     ///
     /// This is helpful when the merkle root is taking too long to calculate.
-    pub fn disable_merkle_root_calculation(mut self) -> Self {
+    pub const fn disable_merkle_root_calculation(mut self) -> Self {
         self.disable_merkle_root_calculation = true;
         self
     }

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -11,7 +11,7 @@ use reth_evm::noop::NoopBlockExecutorProvider;
 use reth_node_core::{
     args::{
         utils::{chain_help, chain_value_parser, SUPPORTED_CHAINS},
-        DatabaseArgs, DatadirArgs,
+        DatabaseArgs, DatadirArgs, PerformanceOptimizationArgs,
     },
     dirs::{ChainPath, DataDirPath},
 };
@@ -50,8 +50,9 @@ pub struct EnvironmentArgs {
     #[command(flatten)]
     pub db: DatabaseArgs,
 
-    #[arg(long)]
-    skip_state_root_validation: bool,
+    /// All performance optimization related arguments
+    #[command(flatten)]
+    pub performance_optimization: PerformanceOptimizationArgs,
 }
 
 impl EnvironmentArgs {
@@ -148,7 +149,7 @@ impl EnvironmentArgs {
                     NoopBlockExecutorProvider::default(),
                     config.stages.clone(),
                     prune_modes.clone(),
-                    self.skip_state_root_validation,
+                    self.performance_optimization.skip_state_root_validation,
                 ))
                 .build(factory.clone(), StaticFileProducer::new(factory.clone(), prune_modes));
 

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -49,6 +49,8 @@ pub struct EnvironmentArgs {
     /// All database related arguments
     #[command(flatten)]
     pub db: DatabaseArgs,
+
+    
 }
 
 impl EnvironmentArgs {
@@ -145,6 +147,7 @@ impl EnvironmentArgs {
                     NoopBlockExecutorProvider::default(),
                     config.stages.clone(),
                     prune_modes.clone(),
+                    false,
                 ))
                 .build(factory.clone(), StaticFileProducer::new(factory.clone(), prune_modes));
 

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -50,7 +50,8 @@ pub struct EnvironmentArgs {
     #[command(flatten)]
     pub db: DatabaseArgs,
 
-    
+    #[arg(long)]
+    disable_hashing_stages: bool,
 }
 
 impl EnvironmentArgs {
@@ -147,7 +148,7 @@ impl EnvironmentArgs {
                     NoopBlockExecutorProvider::default(),
                     config.stages.clone(),
                     prune_modes.clone(),
-                    false,
+                    self.disable_hashing_stages,
                 ))
                 .build(factory.clone(), StaticFileProducer::new(factory.clone(), prune_modes));
 

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -51,7 +51,7 @@ pub struct EnvironmentArgs {
     pub db: DatabaseArgs,
 
     #[arg(long)]
-    disable_hashing_stages: bool,
+    skip_state_root_validation: bool,
 }
 
 impl EnvironmentArgs {
@@ -148,7 +148,7 @@ impl EnvironmentArgs {
                     NoopBlockExecutorProvider::default(),
                     config.stages.clone(),
                     prune_modes.clone(),
-                    self.disable_hashing_stages,
+                    self.skip_state_root_validation,
                 ))
                 .build(factory.clone(), StaticFileProducer::new(factory.clone(), prune_modes));
 

--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -164,6 +164,7 @@ impl ImportCommand {
 ///
 /// If configured to execute, all stages will run. Otherwise, only stages that don't require state
 /// will run.
+#[allow(clippy::too_many_arguments)]
 pub fn build_import_pipeline<DB, C, E>(
     config: &Config,
     provider_factory: ProviderFactory<DB>,

--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -52,9 +52,6 @@ pub struct ImportCommand {
     /// remaining stages are executed.
     #[arg(value_name = "IMPORT_PATH", verbatim_doc_comment)]
     path: PathBuf,
-
-    #[arg(long)]
-    skip_state_root_validation: bool,
 }
 
 impl ImportCommand {
@@ -107,7 +104,7 @@ impl ImportCommand {
                 StaticFileProducer::new(provider_factory.clone(), PruneModes::default()),
                 self.no_state,
                 executor.clone(),
-                self.skip_state_root_validation,
+                self.env.performance_optimization.skip_state_root_validation,
             )?;
 
             // override the tip

--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -52,6 +52,9 @@ pub struct ImportCommand {
     /// remaining stages are executed.
     #[arg(value_name = "IMPORT_PATH", verbatim_doc_comment)]
     path: PathBuf,
+
+    #[arg(long)]
+    disable_hashing_stages: bool,
 }
 
 impl ImportCommand {
@@ -104,6 +107,7 @@ impl ImportCommand {
                 StaticFileProducer::new(provider_factory.clone(), PruneModes::default()),
                 self.no_state,
                 executor.clone(),
+                self.disable_hashing_stages,
             )?;
 
             // override the tip
@@ -168,6 +172,7 @@ pub fn build_import_pipeline<DB, C, E>(
     static_file_producer: StaticFileProducer<DB>,
     disable_exec: bool,
     executor: E,
+    disable_hashing_stages: bool,
 ) -> eyre::Result<(Pipeline<DB>, impl Stream<Item = NodeEvent>)>
 where
     DB: Database + Clone + Unpin + 'static,
@@ -219,6 +224,7 @@ where
                 executor,
                 config.stages.clone(),
                 PruneModes::default(),
+                disable_hashing_stages,
             )
             .builder()
             .disable_all_if(&StageId::STATE_REQUIRED, || disable_exec),

--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -54,7 +54,7 @@ pub struct ImportCommand {
     path: PathBuf,
 
     #[arg(long)]
-    disable_hashing_stages: bool,
+    skip_state_root_validation: bool,
 }
 
 impl ImportCommand {
@@ -107,7 +107,7 @@ impl ImportCommand {
                 StaticFileProducer::new(provider_factory.clone(), PruneModes::default()),
                 self.no_state,
                 executor.clone(),
-                self.disable_hashing_stages,
+                self.skip_state_root_validation,
             )?;
 
             // override the tip
@@ -173,7 +173,7 @@ pub fn build_import_pipeline<DB, C, E>(
     static_file_producer: StaticFileProducer<DB>,
     disable_exec: bool,
     executor: E,
-    disable_hashing_stages: bool,
+    skip_state_root_validation: bool,
 ) -> eyre::Result<(Pipeline<DB>, impl Stream<Item = NodeEvent>)>
 where
     DB: Database + Clone + Unpin + 'static,
@@ -225,7 +225,7 @@ where
                 executor,
                 config.stages.clone(),
                 PruneModes::default(),
-                disable_hashing_stages,
+                skip_state_root_validation,
             )
             .builder()
             .disable_all_if(&StageId::STATE_REQUIRED, || disable_exec),

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -10,7 +10,7 @@ use reth_node_core::{
     args::{
         utils::{chain_help, chain_value_parser, SUPPORTED_CHAINS},
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, NetworkArgs, PayloadBuilderArgs,
-        PruningArgs, RpcServerArgs, TxPoolArgs,
+        PerformanceOptimizationArgs, PruningArgs, RpcServerArgs, TxPoolArgs,
     },
     node_config::NodeConfig,
     version,
@@ -111,9 +111,9 @@ pub struct NodeCommand<Ext: clap::Args + fmt::Debug = NoArgs> {
     #[arg(long, default_value_t = false)]
     pub enable_prefetch: bool,
     
-    /// Disable hashing stage
-    #[arg(long, default_value_t = false)]
-    pub skip_state_root_validation: bool,
+    /// All performance optimization related arguments
+    #[command(flatten)]
+    pub performance_optimization: PerformanceOptimizationArgs,
 }
 
 impl NodeCommand {
@@ -161,7 +161,7 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             pruning,
             ext,
             enable_prefetch,
-            skip_state_root_validation,
+            performance_optimization,
         } = self;
         // set up node config
         let mut node_config = NodeConfig {
@@ -179,7 +179,7 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             dev,
             pruning,
             enable_prefetch,
-            skip_state_root_validation,
+            skip_state_root_validation: performance_optimization.skip_state_root_validation,
         };
 
         // Register the prometheus recorder before creating the database,

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -113,7 +113,7 @@ pub struct NodeCommand<Ext: clap::Args + fmt::Debug = NoArgs> {
     
     /// Disable hashing stage
     #[arg(long, default_value_t = false)]
-    pub disable_hashing_stages: bool,
+    pub skip_state_root_validation: bool,
 }
 
 impl NodeCommand {
@@ -161,7 +161,7 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             pruning,
             ext,
             enable_prefetch,
-            disable_hashing_stages,
+            skip_state_root_validation,
         } = self;
         // set up node config
         let mut node_config = NodeConfig {
@@ -179,7 +179,7 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             dev,
             pruning,
             enable_prefetch,
-            disable_hashing_stages,
+            skip_state_root_validation,
         };
 
         // Register the prometheus recorder before creating the database,

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -110,6 +110,10 @@ pub struct NodeCommand<Ext: clap::Args + fmt::Debug = NoArgs> {
     /// Enable prefetch when executing block
     #[arg(long, default_value_t = false)]
     pub enable_prefetch: bool,
+    
+    /// Disable hashing stage
+    #[arg(long, default_value_t = false)]
+    pub disable_hashing_stages: bool,
 }
 
 impl NodeCommand {
@@ -157,8 +161,8 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             pruning,
             ext,
             enable_prefetch,
+            disable_hashing_stages,
         } = self;
-
         // set up node config
         let mut node_config = NodeConfig {
             datadir,
@@ -175,6 +179,7 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
             dev,
             pruning,
             enable_prefetch,
+            disable_hashing_stages,
         };
 
         // Register the prometheus recorder before creating the database,

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -110,7 +110,7 @@ pub struct NodeCommand<Ext: clap::Args + fmt::Debug = NoArgs> {
     /// Enable prefetch when executing block
     #[arg(long, default_value_t = false)]
     pub enable_prefetch: bool,
-    
+
     /// All performance optimization related arguments
     #[command(flatten)]
     pub performance_optimization: PerformanceOptimizationArgs,

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -42,6 +42,9 @@ pub struct Command {
     /// unwound.
     #[arg(long)]
     offline: bool,
+
+    #[arg(long)]
+    disable_hashing_stages: bool,
 }
 
 impl Command {
@@ -125,7 +128,7 @@ impl Command {
 
         let builder = if self.offline {
             Pipeline::builder().add_stages(
-                OfflineStages::new(executor, config.stages, PruneModes::default())
+                OfflineStages::new(executor, config.stages, PruneModes::default(), self.disable_hashing_stages)
                     .builder()
                     .disable(reth_stages::StageId::SenderRecovery),
             )
@@ -140,6 +143,7 @@ impl Command {
                     executor.clone(),
                     stage_conf.clone(),
                     prune_modes.clone(),
+                    false,
                 )
                 .set(ExecutionStage::new(
                     executor,

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -128,9 +128,14 @@ impl Command {
 
         let builder = if self.offline {
             Pipeline::builder().add_stages(
-                OfflineStages::new(executor, config.stages, PruneModes::default(), self.disable_hashing_stages)
-                    .builder()
-                    .disable(reth_stages::StageId::SenderRecovery),
+                OfflineStages::new(
+                    executor,
+                    config.stages,
+                    PruneModes::default(),
+                    self.disable_hashing_stages,
+                )
+                .builder()
+                .disable(reth_stages::StageId::SenderRecovery),
             )
         } else {
             Pipeline::builder().with_tip_sender(tip_tx).add_stages(

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -44,7 +44,7 @@ pub struct Command {
     offline: bool,
 
     #[arg(long)]
-    disable_hashing_stages: bool,
+    skip_state_root_validation: bool,
 }
 
 impl Command {
@@ -132,7 +132,7 @@ impl Command {
                     executor,
                     config.stages,
                     PruneModes::default(),
-                    self.disable_hashing_stages,
+                    self.skip_state_root_validation,
                 )
                 .builder()
                 .disable(reth_stages::StageId::SenderRecovery),
@@ -148,7 +148,7 @@ impl Command {
                     executor.clone(),
                     stage_conf.clone(),
                     prune_modes.clone(),
-                    self.disable_hashing_stages,
+                    self.skip_state_root_validation,
                 )
                 .set(ExecutionStage::new(
                     executor,

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -148,7 +148,7 @@ impl Command {
                     executor.clone(),
                     stage_conf.clone(),
                     prune_modes.clone(),
-                    false,
+                    self.disable_hashing_stages,
                 )
                 .set(ExecutionStage::new(
                     executor,

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -42,9 +42,6 @@ pub struct Command {
     /// unwound.
     #[arg(long)]
     offline: bool,
-
-    #[arg(long)]
-    skip_state_root_validation: bool,
 }
 
 impl Command {
@@ -132,7 +129,7 @@ impl Command {
                     executor,
                     config.stages,
                     PruneModes::default(),
-                    self.skip_state_root_validation,
+                    self.env.performance_optimization.skip_state_root_validation,
                 )
                 .builder()
                 .disable(reth_stages::StageId::SenderRecovery),
@@ -148,7 +145,7 @@ impl Command {
                     executor.clone(),
                     stage_conf.clone(),
                     prune_modes.clone(),
-                    self.skip_state_root_validation,
+                    self.env.performance_optimization.skip_state_root_validation,
                 )
                 .set(ExecutionStage::new(
                     executor,

--- a/crates/consensus/beacon/src/engine/test_utils.rs
+++ b/crates/consensus/beacon/src/engine/test_utils.rs
@@ -379,6 +379,7 @@ where
                     executor_factory.clone(),
                     StageConfig::default(),
                     PruneModes::default(),
+                    false,
                 ))
             }
         };

--- a/crates/ethereum/node/src/launch.rs
+++ b/crates/ethereum/node/src/launch.rs
@@ -143,7 +143,7 @@ where
             static_file_producer,
             ctx.components().block_executor().clone(),
             pipeline_exex_handle,
-            ctx.node_config().disable_hashing_stages,
+            ctx.node_config().skip_state_root_validation,
         )?;
 
         let pipeline_events = pipeline.events();

--- a/crates/ethereum/node/src/launch.rs
+++ b/crates/ethereum/node/src/launch.rs
@@ -143,6 +143,7 @@ where
             static_file_producer,
             ctx.components().block_executor().clone(),
             pipeline_exex_handle,
+            ctx.node_config().disable_hashing_stages,
         )?;
 
         let pipeline_events = pipeline.events();

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -398,7 +398,7 @@ where
                     NoopBlockExecutorProvider::default(),
                     self.toml_config().stages.clone(),
                     self.prune_modes(),
-                    false,
+                    self.node_config().disable_hashing_stages,
                 ))
                 .build(
                     factory.clone(),

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -398,7 +398,7 @@ where
                     NoopBlockExecutorProvider::default(),
                     self.toml_config().stages.clone(),
                     self.prune_modes(),
-                    self.node_config().disable_hashing_stages,
+                    self.node_config().skip_state_root_validation,
                 ))
                 .build(
                     factory.clone(),
@@ -655,8 +655,8 @@ where
             tree = tree.enable_prefetch();
         }
 
-        if self.node_config().disable_hashing_stages {
-            tree = tree.disable_merkle_root_calculation();
+        if self.node_config().skip_state_root_validation {
+            tree = tree.skip_state_root_validation();
         }
 
         let blockchain_tree = Arc::new(ShareableBlockchainTree::new(tree));

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -641,7 +641,7 @@ where
             consensus.clone(),
             components.block_executor().clone(),
         );
-        
+
         let mut tree =
             BlockchainTree::new(tree_externals, *self.tree_config(), self.prune_modes())?
                 .with_sync_metrics_tx(self.sync_metrics_tx())

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -398,6 +398,7 @@ where
                     NoopBlockExecutorProvider::default(),
                     self.toml_config().stages.clone(),
                     self.prune_modes(),
+                    false,
                 ))
                 .build(
                     factory.clone(),
@@ -640,6 +641,7 @@ where
             consensus.clone(),
             components.block_executor().clone(),
         );
+        
         let mut tree =
             BlockchainTree::new(tree_externals, *self.tree_config(), self.prune_modes())?
                 .with_sync_metrics_tx(self.sync_metrics_tx())
@@ -651,6 +653,10 @@ where
 
         if self.node_config().enable_prefetch {
             tree = tree.enable_prefetch();
+        }
+
+        if self.node_config().disable_hashing_stages {
+            tree = tree.disable_merkle_root_calculation();
         }
 
         let blockchain_tree = Arc::new(ShareableBlockchainTree::new(tree));

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -224,7 +224,7 @@ where
                 static_file_producer,
                 ctx.components().block_executor().clone(),
                 pipeline_exex_handle,
-                ctx.node_config().disable_hashing_stages,
+                ctx.node_config().skip_state_root_validation,
             )?;
 
             let pipeline_events = pipeline.events();
@@ -246,7 +246,7 @@ where
                 static_file_producer,
                 ctx.components().block_executor().clone(),
                 pipeline_exex_handle,
-                ctx.node_config().disable_hashing_stages,
+                ctx.node_config().skip_state_root_validation,
             )?;
             #[cfg(feature = "bsc")]
             {

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -224,6 +224,7 @@ where
                 static_file_producer,
                 ctx.components().block_executor().clone(),
                 pipeline_exex_handle,
+                ctx.node_config().disable_hashing_stages,
             )?;
 
             let pipeline_events = pipeline.events();
@@ -245,6 +246,7 @@ where
                 static_file_producer,
                 ctx.components().block_executor().clone(),
                 pipeline_exex_handle,
+                ctx.node_config().disable_hashing_stages,
             )?;
             #[cfg(feature = "bsc")]
             {

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -84,7 +84,7 @@ pub fn build_pipeline<DB, H, B, Executor>(
     static_file_producer: StaticFileProducer<DB>,
     executor: Executor,
     exex_manager_handle: ExExManagerHandle,
-    disable_hashing_stages: bool,
+    skip_state_root_validation: bool,
 ) -> eyre::Result<Pipeline<DB>>
 where
     DB: Database + Clone + 'static,
@@ -116,7 +116,7 @@ where
                 executor.clone(),
                 stage_config.clone(),
                 prune_modes.clone(),
-                disable_hashing_stages,
+                skip_state_root_validation,
             )
             .set(
                 ExecutionStage::new(

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -36,7 +36,7 @@ pub fn build_networked_pipeline<DB, Client, Executor>(
     static_file_producer: StaticFileProducer<DB>,
     executor: Executor,
     exex_manager_handle: ExExManagerHandle,
-    disable_hash_stages: bool,
+    skip_state_root_validation: bool,
 ) -> eyre::Result<Pipeline<DB>>
 where
     DB: Database + Unpin + Clone + 'static,
@@ -64,7 +64,7 @@ where
         static_file_producer,
         executor,
         exex_manager_handle,
-        disable_hash_stages,
+        skip_state_root_validation,
     )?;
 
     Ok(pipeline)

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -36,6 +36,7 @@ pub fn build_networked_pipeline<DB, Client, Executor>(
     static_file_producer: StaticFileProducer<DB>,
     executor: Executor,
     exex_manager_handle: ExExManagerHandle,
+    disable_hash_stages: bool,
 ) -> eyre::Result<Pipeline<DB>>
 where
     DB: Database + Unpin + Clone + 'static,
@@ -63,6 +64,7 @@ where
         static_file_producer,
         executor,
         exex_manager_handle,
+        disable_hash_stages,
     )?;
 
     Ok(pipeline)
@@ -82,6 +84,7 @@ pub fn build_pipeline<DB, H, B, Executor>(
     static_file_producer: StaticFileProducer<DB>,
     executor: Executor,
     exex_manager_handle: ExExManagerHandle,
+    disable_hashing_stages: bool,
 ) -> eyre::Result<Pipeline<DB>>
 where
     DB: Database + Clone + 'static,
@@ -113,6 +116,7 @@ where
                 executor.clone(),
                 stage_config.clone(),
                 prune_modes.clone(),
+                disable_hashing_stages,
             )
             .set(
                 ExecutionStage::new(

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -56,6 +56,10 @@ pub use datadir_args::DatadirArgs;
 mod benchmark_args;
 pub use benchmark_args::BenchmarkArgs;
 
+/// PerformanceOptimizationArgs struct for configuring performance optimization
+mod performance_optimization;
+pub use performance_optimization::PerformanceOptimizationArgs;
+
 pub mod utils;
 
 pub mod types;

--- a/crates/node/core/src/args/performance_optimization.rs
+++ b/crates/node/core/src/args/performance_optimization.rs
@@ -6,9 +6,10 @@ use clap::Args;
 #[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
 #[command(next_help_heading = "Performance Optimization")]
 pub struct PerformanceOptimizationArgs {
-    /// Skip state root validation during block import.
-    /// This flag is useful for performance optimization when importing blocks from trusted
+    /// Skips state root validation during block import.
+    /// This flag is intended for performance optimization when importing blocks from trusted
     /// sources.
+    /// **Warning: This option compromises the validation of chain data. Use with caution.**
     #[arg(long = "skip-state-root-validation", default_value_t = false)]
     pub skip_state_root_validation: bool,
 }

--- a/crates/node/core/src/args/performance_optimization.rs
+++ b/crates/node/core/src/args/performance_optimization.rs
@@ -1,0 +1,13 @@
+//! Performance optimization arguments
+
+use clap::Args;
+
+/// Parameters for performance optimization
+#[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
+#[command(next_help_heading = "Performance Optimization")]
+pub struct PerformanceOptimizationArgs {
+    /// Skip state root validation during block import.
+    /// This flag is useful for performance optimization when importing blocks from trusted sources.
+    #[arg(long = "skip-state-root-validation", default_value_t = false)]
+    pub skip_state_root_validation: bool,
+}

--- a/crates/node/core/src/args/performance_optimization.rs
+++ b/crates/node/core/src/args/performance_optimization.rs
@@ -7,7 +7,8 @@ use clap::Args;
 #[command(next_help_heading = "Performance Optimization")]
 pub struct PerformanceOptimizationArgs {
     /// Skip state root validation during block import.
-    /// This flag is useful for performance optimization when importing blocks from trusted sources.
+    /// This flag is useful for performance optimization when importing blocks from trusted
+    /// sources.
     #[arg(long = "skip-state-root-validation", default_value_t = false)]
     pub skip_state_root_validation: bool,
 }

--- a/crates/node/core/src/args/performance_optimization.rs
+++ b/crates/node/core/src/args/performance_optimization.rs
@@ -10,6 +10,6 @@ pub struct PerformanceOptimizationArgs {
     /// This flag is intended for performance optimization when importing blocks from trusted
     /// sources.
     /// **Warning: This option compromises the validation of chain data. Use with caution.**
-    #[arg(long = "skip-state-root-validation", default_value_t = false)]
+    #[arg(long = "optimize.skip-state-root-validation", default_value_t = false)]
     pub skip_state_root_validation: bool,
 }

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -148,6 +148,9 @@ pub struct NodeConfig {
 
     /// Enable prefetch when executing blocks.
     pub enable_prefetch: bool,
+
+    /// Disable hashing stages to skip merkle tree building
+    pub disable_hashing_stages: bool,
 }
 
 impl NodeConfig {
@@ -440,6 +443,7 @@ impl Default for NodeConfig {
             pruning: PruningArgs::default(),
             datadir: DatadirArgs::default(),
             enable_prefetch: false,
+            disable_hashing_stages: false,
         }
     }
 }

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -150,7 +150,7 @@ pub struct NodeConfig {
     pub enable_prefetch: bool,
 
     /// Disable hashing stages to skip merkle tree building
-    pub disable_hashing_stages: bool,
+    pub skip_state_root_validation: bool,
 }
 
 impl NodeConfig {
@@ -443,7 +443,7 @@ impl Default for NodeConfig {
             pruning: PruningArgs::default(),
             datadir: DatadirArgs::default(),
             enable_prefetch: false,
-            disable_hashing_stages: false,
+            skip_state_root_validation: false,
         }
     }
 }

--- a/crates/optimism/cli/src/commands/build_pipeline.rs
+++ b/crates/optimism/cli/src/commands/build_pipeline.rs
@@ -33,7 +33,7 @@ pub(crate) async fn build_import_pipeline<DB, C>(
     file_client: Arc<FileClient>,
     static_file_producer: StaticFileProducer<DB>,
     disable_exec: bool,
-    disable_hashing_stages: bool,
+    skip_state_root_validation: bool,
 ) -> eyre::Result<(Pipeline<DB>, impl Stream<Item = NodeEvent>)>
 where
     DB: Database + Clone + Unpin + 'static,
@@ -85,7 +85,7 @@ where
                 executor,
                 config.stages.clone(),
                 PruneModes::default(),
-                disable_hashing_stages,
+                skip_state_root_validation,
             )
             .builder()
             .disable_all_if(&StageId::STATE_REQUIRED, || disable_exec),

--- a/crates/optimism/cli/src/commands/build_pipeline.rs
+++ b/crates/optimism/cli/src/commands/build_pipeline.rs
@@ -33,6 +33,7 @@ pub(crate) async fn build_import_pipeline<DB, C>(
     file_client: Arc<FileClient>,
     static_file_producer: StaticFileProducer<DB>,
     disable_exec: bool,
+    disable_hashing_stages: bool,
 ) -> eyre::Result<(Pipeline<DB>, impl Stream<Item = NodeEvent>)>
 where
     DB: Database + Clone + Unpin + 'static,
@@ -84,6 +85,7 @@ where
                 executor,
                 config.stages.clone(),
                 PruneModes::default(),
+                disable_hashing_stages,
             )
             .builder()
             .disable_all_if(&StageId::STATE_REQUIRED, || disable_exec),

--- a/crates/optimism/cli/src/commands/import.rs
+++ b/crates/optimism/cli/src/commands/import.rs
@@ -35,6 +35,9 @@ pub struct ImportOpCommand {
     /// remaining stages are executed.
     #[arg(value_name = "IMPORT_PATH", verbatim_doc_comment)]
     path: PathBuf,
+
+    #[arg(long)]
+    disable_hashing_stages: bool,
 }
 
 impl ImportOpCommand {
@@ -92,6 +95,7 @@ impl ImportOpCommand {
                 Arc::new(file_client),
                 StaticFileProducer::new(provider_factory.clone(), PruneModes::default()),
                 true,
+                self.disable_hash_stages,
             )
             .await?;
 

--- a/crates/optimism/cli/src/commands/import.rs
+++ b/crates/optimism/cli/src/commands/import.rs
@@ -95,7 +95,7 @@ impl ImportOpCommand {
                 Arc::new(file_client),
                 StaticFileProducer::new(provider_factory.clone(), PruneModes::default()),
                 true,
-                self.disable_hash_stages,
+                self.disable_hashing_stages,
             )
             .await?;
 

--- a/crates/optimism/cli/src/commands/import.rs
+++ b/crates/optimism/cli/src/commands/import.rs
@@ -37,7 +37,7 @@ pub struct ImportOpCommand {
     path: PathBuf,
 
     #[arg(long)]
-    disable_hashing_stages: bool,
+    skip_state_root_validation: bool,
 }
 
 impl ImportOpCommand {
@@ -95,7 +95,7 @@ impl ImportOpCommand {
                 Arc::new(file_client),
                 StaticFileProducer::new(provider_factory.clone(), PruneModes::default()),
                 true,
-                self.disable_hashing_stages,
+                self.skip_state_root_validation,
             )
             .await?;
 

--- a/crates/optimism/cli/src/commands/import.rs
+++ b/crates/optimism/cli/src/commands/import.rs
@@ -35,9 +35,6 @@ pub struct ImportOpCommand {
     /// remaining stages are executed.
     #[arg(value_name = "IMPORT_PATH", verbatim_doc_comment)]
     path: PathBuf,
-
-    #[arg(long)]
-    skip_state_root_validation: bool,
 }
 
 impl ImportOpCommand {
@@ -95,7 +92,7 @@ impl ImportOpCommand {
                 Arc::new(file_client),
                 StaticFileProducer::new(provider_factory.clone(), PruneModes::default()),
                 true,
-                self.skip_state_root_validation,
+                self.env.performance_optimization.skip_state_root_validation,
             )
             .await?;
 

--- a/crates/stages/api/src/pipeline/set.rs
+++ b/crates/stages/api/src/pipeline/set.rs
@@ -138,6 +138,18 @@ where
         self
     }
 
+    /// Adds the given [`StageSet`] at the end of this set if it's [`Some`].
+    ///
+    /// If a stage is in both sets, it is removed from its previous place in this set. Because of
+    /// this, it is advisable to merge sets first and re-order stages after if needed.
+    pub fn add_set_opt<Set: StageSet<DB>>(self, set: Option<Set>) -> Self {
+        if let Some(set) = set {
+            self.add_set(set)
+        } else {
+            self
+        }
+    }
+
     /// Adds the given [`Stage`] before the stage with the given [`StageId`].
     ///
     /// If the stage was already in the group, it is removed from its previous place.

--- a/crates/stages/stages/src/lib.rs
+++ b/crates/stages/stages/src/lib.rs
@@ -64,6 +64,7 @@
 //!         executor_provider,
 //!         StageConfig::default(),
 //!         PruneModes::default(),
+//!         false,
 //!     ))
 //!     .build(provider_factory, static_file_producer);
 //! ```

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -137,7 +137,12 @@ where
     ) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_set(default_offline)
-            .add_set(OfflineStages::new(executor_factory, stages_config, prune_modes, disable_hashing_stages))
+            .add_set(OfflineStages::new(
+                executor_factory,
+                stages_config,
+                prune_modes,
+                disable_hashing_stages,
+            ))
             .add_stage(FinishStage)
     }
 }
@@ -300,9 +305,11 @@ where
         .add_stage_opt(self.prune_modes.sender_recovery.map(|prune_mode| {
             PruneSenderRecoveryStage::new(prune_mode, self.stages_config.prune.commit_threshold)
         }))
-        .add_set_opt(self.disable_hashing.not().then(|| {
-            HashingStages { stages_config: self.stages_config.clone() }
-        }))
+        .add_set_opt(
+            self.disable_hashing
+                .not()
+                .then(|| HashingStages { stages_config: self.stages_config.clone() }),
+        )
         .add_set(HistoryIndexingStages {
             stages_config: self.stages_config.clone(),
             prune_modes: self.prune_modes.clone(),

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -85,7 +85,7 @@ pub struct DefaultStages<Provider, H, B, EF> {
     stages_config: StageConfig,
     /// Prune configuration for every segment that can be pruned
     prune_modes: PruneModes,
-    /// Disable hashing stages(Merkle, AccountHashing, StorageHashing)
+    /// Disable hashing stages(`Merkle`, `AccountHashing`, `StorageHashing`)
     disable_hashing_stages: bool,
 }
 
@@ -273,7 +273,7 @@ pub struct OfflineStages<EF> {
     stages_config: StageConfig,
     /// Prune configuration for every segment that can be pruned
     prune_modes: PruneModes,
-    /// Disable hashing stages(Merkle, AccountHashing, StorageHashing)
+    /// Disable hashing stages(`Merkle`, `AccountHashing`, `StorageHashing`)
     disable_hashing: bool,
 }
 

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -86,7 +86,7 @@ pub struct DefaultStages<Provider, H, B, EF> {
     /// Prune configuration for every segment that can be pruned
     prune_modes: PruneModes,
     /// Disable hashing stages(`Merkle`, `AccountHashing`, `StorageHashing`)
-    disable_hashing_stages: bool,
+    skip_state_root_validation: bool,
 }
 
 impl<Provider, H, B, E> DefaultStages<Provider, H, B, E> {
@@ -101,7 +101,7 @@ impl<Provider, H, B, E> DefaultStages<Provider, H, B, E> {
         executor_factory: E,
         stages_config: StageConfig,
         prune_modes: PruneModes,
-        disable_hashing_stages: bool,
+        skip_state_root_validation: bool,
     ) -> Self
     where
         E: BlockExecutorProvider,
@@ -118,7 +118,7 @@ impl<Provider, H, B, E> DefaultStages<Provider, H, B, E> {
             executor_factory,
             stages_config,
             prune_modes,
-            disable_hashing_stages,
+            skip_state_root_validation,
         }
     }
 }
@@ -133,7 +133,7 @@ where
         executor_factory: E,
         stages_config: StageConfig,
         prune_modes: PruneModes,
-        disable_hashing_stages: bool,
+        skip_state_root_validation: bool,
     ) -> StageSetBuilder<DB> {
         StageSetBuilder::default()
             .add_set(default_offline)
@@ -141,7 +141,7 @@ where
                 executor_factory,
                 stages_config,
                 prune_modes,
-                disable_hashing_stages,
+                skip_state_root_validation,
             ))
             .add_stage(FinishStage)
     }
@@ -161,7 +161,7 @@ where
             self.executor_factory,
             self.stages_config.clone(),
             self.prune_modes,
-            self.disable_hashing_stages,
+            self.skip_state_root_validation,
         )
     }
 }


### PR DESCRIPTION
### Description

support importing blocks without merkle calculation mode

### Rationale

Add a flag `--optimize.skip-state-root-validation` to disable state root calculation during block importing. This can be useful if the state root calculation is taking too long.
However, be cautious when using this mode, as the accuracy of node data (PlainState) will no longer be strongly guaranteed.

### Example

1. start a node with `--optimize.skip-state-root-validation` flag
```bash
bsc-reth node --chain bsc --http --http.port 8545 --optimize.skip-state-root-validation
```
(*Optional*) 2. Clear Trie/Hashed Account/Storage table to save database cost.
```
bsc-reth db clear mdbx StoragesTrie
bsc-reth db clear mdbx AccountsTrie
bsc-reth db clear mdbx HashedAccounts
bsc-reth db clear mdbx HashedStorages

bsc-reth db stats
```

### Changes

Notable changes: 
* add new flag to start nodes bypassing merkle root calculation

### Potential Impacts
* no
