### PR TITLE
fix: bsc `BLS_SIGNATURE_VALIDATION` precompile contract error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## V1.0.3
+This is a bugfix version.
+
+### BUGFIX
+* [\#119](https://github.com/bnb-chain/reth/pull/119) fix: sidecars missing issue and empty validators election info issue
+* [\#122](https://github.com/bnb-chain/reth/pull/122) fix: bsc snapshot issues
+* [\#125](https://github.com/bnb-chain/reth/pull/125) fix: bsc `BLS_SIGNATURE_VALIDATION` precompile contract error
+
 ## V1.0.2
 This release is for BSC mainnet HaberFix and Bohr upgrade and opBNB mainnet Wright upgrade.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "12.1.0"
-source = "git+https://github.com/bnb-chain/revm?tag=v1.0.1#0ba000fbdf2bfb9b01c5cb862b0f13b5ab4ee98d"
+source = "git+https://github.com/bnb-chain/revm?rev=7a4d6dd982bb3db6d604e289890ef303c22d998d#7a4d6dd982bb3db6d604e289890ef303c22d998d"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "8.1.0"
-source = "git+https://github.com/bnb-chain/revm?tag=v1.0.1#0ba000fbdf2bfb9b01c5cb862b0f13b5ab4ee98d"
+source = "git+https://github.com/bnb-chain/revm?rev=7a4d6dd982bb3db6d604e289890ef303c22d998d#7a4d6dd982bb3db6d604e289890ef303c22d998d"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "9.2.0"
-source = "git+https://github.com/bnb-chain/revm?tag=v1.0.1#0ba000fbdf2bfb9b01c5cb862b0f13b5ab4ee98d"
+source = "git+https://github.com/bnb-chain/revm?rev=7a4d6dd982bb3db6d604e289890ef303c22d998d#7a4d6dd982bb3db6d604e289890ef303c22d998d"
 dependencies = [
  "alloy-rlp",
  "aurora-engine-modexp",
@@ -9864,7 +9864,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "7.1.0"
-source = "git+https://github.com/bnb-chain/revm?tag=v1.0.1#0ba000fbdf2bfb9b01c5cb862b0f13b5ab4ee98d"
+source = "git+https://github.com/bnb-chain/revm?rev=7a4d6dd982bb3db6d604e289890ef303c22d998d#7a4d6dd982bb3db6d604e289890ef303c22d998d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 rust-version = "1.79"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -554,10 +554,10 @@ test-fuzz = "5"
 iai-callgrind = "0.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.1" }
-revm-interpreter = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.1" }
-revm-precompile = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.1" }
-revm-primitives = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.1" }
+revm = { git = "https://github.com/bnb-chain/revm", rev = "7a4d6dd982bb3db6d604e289890ef303c22d998d" }
+revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "7a4d6dd982bb3db6d604e289890ef303c22d998d" }
+revm-precompile = { git = "https://github.com/bnb-chain/revm", rev = "7a4d6dd982bb3db6d604e289890ef303c22d998d" }
+revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "7a4d6dd982bb3db6d604e289890ef303c22d998d" }
 alloy-chains = { git = "https://github.com/bnb-chain/alloy-chains-rs.git", tag = "v1.0.0" }
 alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }
 alloy-consensus = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }


### PR DESCRIPTION
### Description

This pr is to update revm dep to fix a precompile contract error

### Rationale

The `BLS_SIGNATURE_VALIDATION` function should return empty bytes rather than `0x00` when validation failed 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
