### PR TITLE
updating Cargo.lock dependencies to 1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "rayon",
@@ -7041,7 +7041,7 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -7123,7 +7123,7 @@ dependencies = [
 
 [[package]]
 name = "reth-auto-seal-consensus"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
@@ -7149,7 +7149,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "futures-core",
@@ -7171,7 +7171,7 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-genesis",
  "assert_matches",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7264,7 +7264,7 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-genesis",
  "aquamarine",
@@ -7298,7 +7298,7 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7309,11 +7309,11 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-cli"
-version = "1.0.2"
+version = "1.0.3"
 
 [[package]]
 name = "reth-bsc-consensus"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -7352,7 +7352,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-engine"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -7396,7 +7396,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -7420,7 +7420,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clap",
  "eyre",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "ahash",
  "arbitrary",
@@ -7483,7 +7483,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7492,7 +7492,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7507,7 +7507,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -7539,7 +7539,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "confy",
  "humantime-serde",
@@ -7554,7 +7554,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "auto_impl",
  "reth-primitives",
@@ -7563,7 +7563,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "mockall",
  "rand 0.8.5",
@@ -7575,7 +7575,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7597,7 +7597,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -7636,7 +7636,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -7668,7 +7668,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-genesis",
  "boyer-moore-magiclen",
@@ -7693,7 +7693,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7720,7 +7720,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7746,7 +7746,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "assert_matches",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -7841,7 +7841,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aes 0.8.4",
  "alloy-primitives",
@@ -7871,7 +7871,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-chainspec",
  "reth-payload-primitives",
@@ -7880,7 +7880,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aquamarine",
  "assert_matches",
@@ -7928,7 +7928,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "eyre",
  "futures",
@@ -7946,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -7958,7 +7958,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -7992,7 +7992,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -8013,7 +8013,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8026,7 +8026,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -8037,7 +8037,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "futures",
  "pin-project",
@@ -8056,7 +8056,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "reth-chainspec",
@@ -8074,7 +8074,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-basic-payload-builder",
  "reth-errors",
@@ -8111,7 +8111,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8121,7 +8121,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-eips",
  "auto_impl",
@@ -8139,7 +8139,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-bsc"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bitset",
  "blst",
@@ -8162,7 +8162,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-eips",
  "alloy-sol-types",
@@ -8182,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-optimism"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-chainspec",
  "reth-consensus-common",
@@ -8202,7 +8202,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8215,7 +8215,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8229,7 +8229,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "eyre",
  "futures",
@@ -8263,7 +8263,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "eyre",
  "futures-util",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "reth-provider",
@@ -8302,7 +8302,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -8311,7 +8311,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "bytes 1.7.0",
@@ -8333,7 +8333,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -8353,7 +8353,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -8361,7 +8361,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "futures",
  "metrics",
@@ -8372,7 +8372,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics-derive"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "metrics",
  "once_cell",
@@ -8386,14 +8386,14 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "futures-util",
  "reqwest 0.12.5",
@@ -8405,7 +8405,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-node-bindings",
  "alloy-provider",
@@ -8463,7 +8463,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -8477,7 +8477,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "auto_impl",
  "futures",
@@ -8495,7 +8495,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8511,7 +8511,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "humantime-serde",
  "reth-net-banlist",
@@ -8524,7 +8524,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8545,7 +8545,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-db-api",
  "reth-engine-primitives",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-bsc"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "eyre",
  "futures",
@@ -8591,7 +8591,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aquamarine",
  "backon",
@@ -8646,7 +8646,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -8707,7 +8707,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rpc-types-engine",
  "futures",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-optimism"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -8820,7 +8820,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -8859,7 +8859,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -8870,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "reth-basic-payload-builder",
@@ -8894,11 +8894,11 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.0.2"
+version = "1.0.3"
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "futures-util",
  "metrics",
@@ -8948,7 +8948,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-chainspec",
  "reth-errors",
@@ -8962,7 +8962,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-chainspec",
  "reth-primitives",
@@ -8972,7 +8972,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -9021,7 +9021,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9048,7 +9048,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9091,7 +9091,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9141,7 +9141,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-eips",
  "reth-chainspec",
@@ -9159,7 +9159,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-genesis",
@@ -9217,7 +9217,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "jsonrpsee",
  "reth-engine-primitives",
@@ -9230,7 +9230,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clap",
  "http 1.1.0",
@@ -9291,7 +9291,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "assert_matches",
@@ -9324,7 +9324,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-dyn-abi",
  "async-trait",
@@ -9356,7 +9356,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-sol-types",
  "derive_more",
@@ -9393,7 +9393,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rpc-types-engine",
  "assert_matches",
@@ -9410,7 +9410,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee-core",
@@ -9425,7 +9425,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -9449,7 +9449,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types-compat"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
@@ -9461,7 +9461,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "assert_matches",
@@ -9509,7 +9509,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -9538,7 +9538,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9556,7 +9556,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -9579,7 +9579,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9590,7 +9590,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "auto_impl",
  "reth-chainspec",
@@ -9606,7 +9606,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "reth-fs-util",
  "reth-primitives",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9632,7 +9632,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-genesis",
  "rand 0.8.5",
@@ -9642,7 +9642,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9651,7 +9651,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clap",
  "eyre",
@@ -9665,7 +9665,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -9705,7 +9705,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -9739,7 +9739,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9768,7 +9768,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-rlp",
  "criterion",


### PR DESCRIPTION
### Description

Updates the dependencies in Cargo.lock to 1.0.3

### Rationale

Docker build fails with:

```
    Updating crates.io index
error: the lock file /app/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
The command '/bin/sh -c cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin bsc-reth' returned a non-zero code: 101
```

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
