### PR TITLE
feat: support new engine on bsc-reth

### DIFF
--- a/bin/reth/src/bsc.rs
+++ b/bin/reth/src/bsc.rs
@@ -8,10 +8,25 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[cfg(not(feature = "bsc"))]
 compile_error!("Cannot build the `bsc-reth` binary with the `bsc` feature flag disabled.");
 
+/// clap [Args] for Engine related arguments.
+use clap::Args;
+
+/// Parameters for configuring the engine
+#[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
+#[command(next_help_heading = "Engine")]
+pub struct EngineArgs {
+    /// Enable the engine2 experimental features on reth binary
+    #[arg(long = "engine.experimental", default_value = "false")]
+    pub experimental: bool,
+}
+
 #[cfg(feature = "bsc")]
 fn main() {
+    use clap::Parser;
     use reth::cli::Cli;
-    use reth_node_bsc::BscNode;
+    use reth_node_bsc::{node::BSCAddOns, BscNode};
+    use reth_node_builder::EngineNodeLauncher;
+    use reth_provider::providers::BlockchainProvider2;
 
     reth_cli_util::sigsegv_handler::install();
 
@@ -20,9 +35,29 @@ fn main() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
 
-    if let Err(err) = Cli::parse_args().run(|builder, _| async {
-        let handle = builder.launch_node(BscNode::default()).await?;
-        handle.node_exit_future.await
+    if let Err(err) = Cli::<EngineArgs>::parse().run(|builder, engine_args| async move {
+        let enable_engine2 = engine_args.experimental;
+        match enable_engine2 {
+            true => {
+                let handle = builder
+                    .with_types_and_provider::<BscNode, BlockchainProvider2<_>>()
+                    .with_components(BscNode::components())
+                    .with_add_ons::<BSCAddOns>()
+                    .launch_with_fn(|builder| {
+                        let launcher = EngineNodeLauncher::new(
+                            builder.task_executor().clone(),
+                            builder.config().datadir(),
+                        );
+                        builder.launch_with(launcher)
+                    })
+                    .await?;
+                handle.node_exit_future.await
+            }
+            false => {
+                let handle = builder.launch_node(BscNode::default()).await?;
+                handle.node_exit_future.await
+            }
+        }
     }) {
         eprintln!("Error: {err:?}");
         std::process::exit(1);

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -6,6 +6,8 @@ use reth_beacon_consensus::{
     BeaconConsensusEngineHandle,
 };
 use reth_blockchain_tree::BlockchainTreeConfig;
+#[cfg(feature = "bsc")]
+use reth_bsc_engine::ParliaEngineBuilder;
 use reth_chainspec::ChainSpec;
 use reth_engine_service::service::{ChainEvent, EngineService};
 use reth_engine_tree::{
@@ -15,6 +17,8 @@ use reth_engine_tree::{
 use reth_engine_util::EngineMessageStreamExt;
 use reth_exex::ExExManagerHandle;
 use reth_network::{NetworkSyncUpdater, SyncState};
+#[cfg(feature = "bsc")]
+use reth_network_api::EngineRxProvider;
 use reth_network_api::{BlockDownloaderProvider, NetworkEventListenerProvider};
 use reth_node_api::{BuiltPayload, FullNodeTypes, NodeAddOns};
 use reth_node_core::{
@@ -25,6 +29,8 @@ use reth_node_core::{
     version::{CARGO_PKG_VERSION, CLIENT_CODE, NAME_CLIENT, VERGEN_GIT_SHA},
 };
 use reth_node_events::{cl::ConsensusLayerHealthEvents, node};
+#[cfg(feature = "bsc")]
+use reth_primitives::parlia::ParliaConfig;
 use reth_provider::providers::BlockchainProvider2;
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_rpc_types::{engine::ClientVersionV1, WithOtherFields};
@@ -203,20 +209,55 @@ where
         info!(target: "reth::cli", prune_config=?ctx.prune_config().unwrap_or_default(), "Pruner initialized");
 
         // Configure the consensus engine
-        let mut eth_service = EngineService::new(
-            ctx.consensus(),
-            ctx.components().block_executor().clone(),
-            ctx.chain_spec(),
-            network_client.clone(),
-            Box::pin(consensus_engine_stream),
-            pipeline,
-            Box::new(ctx.task_executor().clone()),
-            ctx.provider_factory().clone(),
-            ctx.blockchain_db().clone(),
-            pruner,
-            ctx.components().payload_builder().clone(),
-            TreeConfig::default(),
-        );
+        let mut eth_service = {
+            #[cfg(not(feature = "bsc"))]
+            {
+                let eth_service = EngineService::new(
+                    ctx.consensus(),
+                    ctx.components().block_executor().clone(),
+                    ctx.chain_spec(),
+                    network_client.clone(),
+                    Box::pin(consensus_engine_stream),
+                    pipeline,
+                    Box::new(ctx.task_executor().clone()),
+                    ctx.provider_factory().clone(),
+                    ctx.blockchain_db().clone(),
+                    pruner,
+                    ctx.components().payload_builder().clone(),
+                    TreeConfig::default(),
+                );
+                eth_service
+            }
+            #[cfg(feature = "bsc")]
+            {
+                let engine_rx = ctx.node_adapter().components.network().get_to_engine_rx();
+                let client = ParliaEngineBuilder::new(
+                    ctx.chain_spec(),
+                    ParliaConfig::default(),
+                    ctx.blockchain_db().clone(),
+                    ctx.blockchain_db().clone(),
+                    consensus_engine_tx.clone(),
+                    engine_rx,
+                    network_client.clone(),
+                )
+                .build(ctx.node_config().debug.tip.is_none());
+                let eth_service = EngineService::new(
+                    ctx.consensus(),
+                    ctx.components().block_executor().clone(),
+                    ctx.chain_spec(),
+                    client.clone(),
+                    Box::pin(consensus_engine_stream),
+                    pipeline,
+                    Box::new(ctx.task_executor().clone()),
+                    ctx.provider_factory().clone(),
+                    ctx.blockchain_db().clone(),
+                    pruner,
+                    ctx.components().payload_builder().clone(),
+                    TreeConfig::default(),
+                );
+                eth_service
+            }
+        };
 
         let event_sender = EventSender::default();
 


### PR DESCRIPTION
### Description

support `bsc-reth` to start with `--engine.experimental` flag.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
