### PR TITLE
fix: typo in `BSC_CHAPEL`

### DIFF
--- a/crates/bsc/chainspec/src/bsc_chapel.rs
+++ b/crates/bsc/chainspec/src/bsc_chapel.rs
@@ -18,7 +18,7 @@ pub static BSC_CHAPEL: Lazy<Arc<BscChainSpec>> = Lazy::new(|| {
     BscChainSpec {
         inner: ChainSpec {
             chain: Chain::from_named(NamedChain::BNBSmartChainTestnet),
-            genesis: serde_json::from_str(include_str!("../res/genesis/bsc_rialto.json"))
+            genesis: serde_json::from_str(include_str!("../res/genesis/bsc_chapel.json"))
                 .expect("Can't deserialize BSC Testnet genesis json"),
             genesis_hash: Some(b256!(
                 "6d3c66c5357ec91d5c43af47e234a939b22557cbb552dc45bebbceeed90fbe34"


### PR DESCRIPTION
### Description

The genesis file should be `bsc_chapel.json`

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
