### PR TITLE
feat: add Fjord upgrade time for opBNB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "12.1.0"
-source = "git+https://github.com/bnb-chain/revm?rev=e4db8dab99387b6c21f18cedf0e14ab6a8c10774#e4db8dab99387b6c21f18cedf0e14ab6a8c10774"
+source = "git+https://github.com/bnb-chain/revm?rev=2a51505c2c550a2e445feff3d2e5d72f599ed4b6#2a51505c2c550a2e445feff3d2e5d72f599ed4b6"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "8.1.0"
-source = "git+https://github.com/bnb-chain/revm?rev=e4db8dab99387b6c21f18cedf0e14ab6a8c10774#e4db8dab99387b6c21f18cedf0e14ab6a8c10774"
+source = "git+https://github.com/bnb-chain/revm?rev=2a51505c2c550a2e445feff3d2e5d72f599ed4b6#2a51505c2c550a2e445feff3d2e5d72f599ed4b6"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "9.2.0"
-source = "git+https://github.com/bnb-chain/revm?rev=e4db8dab99387b6c21f18cedf0e14ab6a8c10774#e4db8dab99387b6c21f18cedf0e14ab6a8c10774"
+source = "git+https://github.com/bnb-chain/revm?rev=2a51505c2c550a2e445feff3d2e5d72f599ed4b6#2a51505c2c550a2e445feff3d2e5d72f599ed4b6"
 dependencies = [
  "alloy-rlp",
  "aurora-engine-modexp",
@@ -9864,7 +9864,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "7.1.0"
-source = "git+https://github.com/bnb-chain/revm?rev=e4db8dab99387b6c21f18cedf0e14ab6a8c10774#e4db8dab99387b6c21f18cedf0e14ab6a8c10774"
+source = "git+https://github.com/bnb-chain/revm?rev=2a51505c2c550a2e445feff3d2e5d72f599ed4b6#2a51505c2c550a2e445feff3d2e5d72f599ed4b6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "12.1.0"
-source = "git+https://github.com/bnb-chain/revm?tag=v1.0.1#0ba000fbdf2bfb9b01c5cb862b0f13b5ab4ee98d"
+source = "git+https://github.com/bnb-chain/revm?rev=5647ca79aacb6c479030ba256ceec55095a0fc2f#5647ca79aacb6c479030ba256ceec55095a0fc2f"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "8.1.0"
-source = "git+https://github.com/bnb-chain/revm?tag=v1.0.1#0ba000fbdf2bfb9b01c5cb862b0f13b5ab4ee98d"
+source = "git+https://github.com/bnb-chain/revm?rev=5647ca79aacb6c479030ba256ceec55095a0fc2f#5647ca79aacb6c479030ba256ceec55095a0fc2f"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "9.2.0"
-source = "git+https://github.com/bnb-chain/revm?tag=v1.0.1#0ba000fbdf2bfb9b01c5cb862b0f13b5ab4ee98d"
+source = "git+https://github.com/bnb-chain/revm?rev=5647ca79aacb6c479030ba256ceec55095a0fc2f#5647ca79aacb6c479030ba256ceec55095a0fc2f"
 dependencies = [
  "alloy-rlp",
  "aurora-engine-modexp",
@@ -9864,7 +9864,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "7.1.0"
-source = "git+https://github.com/bnb-chain/revm?tag=v1.0.1#0ba000fbdf2bfb9b01c5cb862b0f13b5ab4ee98d"
+source = "git+https://github.com/bnb-chain/revm?rev=5647ca79aacb6c479030ba256ceec55095a0fc2f#5647ca79aacb6c479030ba256ceec55095a0fc2f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "12.1.0"
-source = "git+https://github.com/bnb-chain/revm?rev=2a51505c2c550a2e445feff3d2e5d72f599ed4b6#2a51505c2c550a2e445feff3d2e5d72f599ed4b6"
+source = "git+https://github.com/bnb-chain/revm?tag=v1.0.2#7922c223d8b082b5d1cd79fa9d299012da685259"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "8.1.0"
-source = "git+https://github.com/bnb-chain/revm?rev=2a51505c2c550a2e445feff3d2e5d72f599ed4b6#2a51505c2c550a2e445feff3d2e5d72f599ed4b6"
+source = "git+https://github.com/bnb-chain/revm?tag=v1.0.2#7922c223d8b082b5d1cd79fa9d299012da685259"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "9.2.0"
-source = "git+https://github.com/bnb-chain/revm?rev=2a51505c2c550a2e445feff3d2e5d72f599ed4b6#2a51505c2c550a2e445feff3d2e5d72f599ed4b6"
+source = "git+https://github.com/bnb-chain/revm?tag=v1.0.2#7922c223d8b082b5d1cd79fa9d299012da685259"
 dependencies = [
  "alloy-rlp",
  "aurora-engine-modexp",
@@ -9864,7 +9864,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "7.1.0"
-source = "git+https://github.com/bnb-chain/revm?rev=2a51505c2c550a2e445feff3d2e5d72f599ed4b6#2a51505c2c550a2e445feff3d2e5d72f599ed4b6"
+source = "git+https://github.com/bnb-chain/revm?tag=v1.0.2#7922c223d8b082b5d1cd79fa9d299012da685259"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "12.1.0"
-source = "git+https://github.com/bnb-chain/revm?rev=5647ca79aacb6c479030ba256ceec55095a0fc2f#5647ca79aacb6c479030ba256ceec55095a0fc2f"
+source = "git+https://github.com/bnb-chain/revm?rev=e4db8dab99387b6c21f18cedf0e14ab6a8c10774#e4db8dab99387b6c21f18cedf0e14ab6a8c10774"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "8.1.0"
-source = "git+https://github.com/bnb-chain/revm?rev=5647ca79aacb6c479030ba256ceec55095a0fc2f#5647ca79aacb6c479030ba256ceec55095a0fc2f"
+source = "git+https://github.com/bnb-chain/revm?rev=e4db8dab99387b6c21f18cedf0e14ab6a8c10774#e4db8dab99387b6c21f18cedf0e14ab6a8c10774"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "9.2.0"
-source = "git+https://github.com/bnb-chain/revm?rev=5647ca79aacb6c479030ba256ceec55095a0fc2f#5647ca79aacb6c479030ba256ceec55095a0fc2f"
+source = "git+https://github.com/bnb-chain/revm?rev=e4db8dab99387b6c21f18cedf0e14ab6a8c10774#e4db8dab99387b6c21f18cedf0e14ab6a8c10774"
 dependencies = [
  "alloy-rlp",
  "aurora-engine-modexp",
@@ -9864,7 +9864,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "7.1.0"
-source = "git+https://github.com/bnb-chain/revm?rev=5647ca79aacb6c479030ba256ceec55095a0fc2f#5647ca79aacb6c479030ba256ceec55095a0fc2f"
+source = "git+https://github.com/bnb-chain/revm?rev=e4db8dab99387b6c21f18cedf0e14ab6a8c10774#e4db8dab99387b6c21f18cedf0e14ab6a8c10774"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -554,10 +554,10 @@ test-fuzz = "5"
 iai-callgrind = "0.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.1" }
-revm-interpreter = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.1" }
-revm-precompile = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.1" }
-revm-primitives = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.1" }
+revm = { git = "https://github.com/bnb-chain/revm", rev = "5647ca79aacb6c479030ba256ceec55095a0fc2f" }
+revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "5647ca79aacb6c479030ba256ceec55095a0fc2f" }
+revm-precompile = { git = "https://github.com/bnb-chain/revm", rev = "5647ca79aacb6c479030ba256ceec55095a0fc2f" }
+revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "5647ca79aacb6c479030ba256ceec55095a0fc2f" }
 alloy-chains = { git = "https://github.com/bnb-chain/alloy-chains-rs.git", tag = "v1.0.0" }
 alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }
 alloy-consensus = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -554,10 +554,10 @@ test-fuzz = "5"
 iai-callgrind = "0.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bnb-chain/revm", rev = "5647ca79aacb6c479030ba256ceec55095a0fc2f" }
-revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "5647ca79aacb6c479030ba256ceec55095a0fc2f" }
-revm-precompile = { git = "https://github.com/bnb-chain/revm", rev = "5647ca79aacb6c479030ba256ceec55095a0fc2f" }
-revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "5647ca79aacb6c479030ba256ceec55095a0fc2f" }
+revm = { git = "https://github.com/bnb-chain/revm", rev = "e4db8dab99387b6c21f18cedf0e14ab6a8c10774" }
+revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "e4db8dab99387b6c21f18cedf0e14ab6a8c10774" }
+revm-precompile = { git = "https://github.com/bnb-chain/revm", rev = "e4db8dab99387b6c21f18cedf0e14ab6a8c10774" }
+revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "e4db8dab99387b6c21f18cedf0e14ab6a8c10774" }
 alloy-chains = { git = "https://github.com/bnb-chain/alloy-chains-rs.git", tag = "v1.0.0" }
 alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }
 alloy-consensus = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -554,10 +554,10 @@ test-fuzz = "5"
 iai-callgrind = "0.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bnb-chain/revm", rev = "e4db8dab99387b6c21f18cedf0e14ab6a8c10774" }
-revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "e4db8dab99387b6c21f18cedf0e14ab6a8c10774" }
-revm-precompile = { git = "https://github.com/bnb-chain/revm", rev = "e4db8dab99387b6c21f18cedf0e14ab6a8c10774" }
-revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "e4db8dab99387b6c21f18cedf0e14ab6a8c10774" }
+revm = { git = "https://github.com/bnb-chain/revm", rev = "2a51505c2c550a2e445feff3d2e5d72f599ed4b6" }
+revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "2a51505c2c550a2e445feff3d2e5d72f599ed4b6" }
+revm-precompile = { git = "https://github.com/bnb-chain/revm", rev = "2a51505c2c550a2e445feff3d2e5d72f599ed4b6" }
+revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "2a51505c2c550a2e445feff3d2e5d72f599ed4b6" }
 alloy-chains = { git = "https://github.com/bnb-chain/alloy-chains-rs.git", tag = "v1.0.0" }
 alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }
 alloy-consensus = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -554,10 +554,10 @@ test-fuzz = "5"
 iai-callgrind = "0.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bnb-chain/revm", rev = "2a51505c2c550a2e445feff3d2e5d72f599ed4b6" }
-revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "2a51505c2c550a2e445feff3d2e5d72f599ed4b6" }
-revm-precompile = { git = "https://github.com/bnb-chain/revm", rev = "2a51505c2c550a2e445feff3d2e5d72f599ed4b6" }
-revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "2a51505c2c550a2e445feff3d2e5d72f599ed4b6" }
+revm = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.2" }
+revm-interpreter = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.2" }
+revm-precompile = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.2" }
+revm-primitives = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.2" }
 alloy-chains = { git = "https://github.com/bnb-chain/alloy-chains-rs.git", tag = "v1.0.0" }
 alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }
 alloy-consensus = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -341,11 +341,11 @@ pub static OPBNB_TESTNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
 #[cfg(all(feature = "optimism", feature = "opbnb"))]
 pub static OPBNB_QA: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
     ChainSpec {
-        chain: Chain::from_id(4530),
+        chain: Chain::from_id(3534),
         genesis: serde_json::from_str(include_str!("../res/genesis/opbnb_qa.json"))
             .expect("Can't deserialize opBNB qa genesis json"),
         genesis_hash: Some(b256!(
-            "bb2282e70cc2aebb17342003ad1c0aeab6a8114f8a4718730c13711d787b5de9"
+            "1c2ad01526f22793643de4978dbf5cec5aeaedcb628470de8b950f8a46539ddf"
         )),
         paris_block_and_final_difficulty: Some((0, U256::from(0))),
         hardforks: OptimismHardfork::opbnb_qa(),

--- a/crates/ethereum-forks/src/hardfork/optimism.rs
+++ b/crates/ethereum-forks/src/hardfork/optimism.rs
@@ -456,6 +456,7 @@ impl OptimismHardfork {
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1718871600)),
             (Self::Haber.boxed(), ForkCondition::Timestamp(1718872200)),
             (Self::Wright.boxed(), ForkCondition::Timestamp(1724738400)),
+            (Self::Fjord.boxed(), ForkCondition::Timestamp(1727157600)),
         ])
     }
 
@@ -489,6 +490,7 @@ impl OptimismHardfork {
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(1715754600)),
             (Self::Haber.boxed(), ForkCondition::Timestamp(1717048800)),
             (Self::Wright.boxed(), ForkCondition::Timestamp(1723701600)),
+            (Self::Fjord.boxed(), ForkCondition::Timestamp(1725948000)),
         ])
     }
 
@@ -519,7 +521,9 @@ impl OptimismHardfork {
             (Self::Canyon.boxed(), ForkCondition::Timestamp(0)),
             (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(0)),
             (Self::Ecotone.boxed(), ForkCondition::Timestamp(0)),
+            (Self::Haber.boxed(), ForkCondition::Timestamp(0)),
             (Self::Wright.boxed(), ForkCondition::Timestamp(0)),
+            (Self::Fjord.boxed(), ForkCondition::Timestamp(0)),
         ])
     }
 }


### PR DESCRIPTION
### Description

This pr will add Fjord fork time for opBNB Mainnet and Testnet.

Fjord fork is set to be activated on both the opBNB Mainnet and Testnet environments according to the following schedule:

Testnet: Sep-10-2024 06:00 AM +UTC
Mainnet: Sep-24-2024 06:00 AM +UTC

### Rationale

Add Fjord upgrade time for opBNB

### Example

an

### Changes

Notable changes: 
* add Fjord upgrade time for opBNB

### Potential Impacts

na
