### PR TITLE
fix: add `ancestor_blocks` when executing block in new engine

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1758,8 +1758,16 @@ where
         let sealed_block = Arc::new(block.block.clone());
         let block = block.unseal();
 
+        let ancestor_blocks = self
+            .state
+            .tree_state
+            .blocks_by_hash
+            .iter()
+            .map(|(hash, block)| (*hash, block.block().header.header().clone()))
+            .collect::<HashMap<_, _>>();
+
         let exec_time = Instant::now();
-        let output = executor.execute((&block, U256::MAX, None).into())?;
+        let output = executor.execute((&block, U256::MAX, Some(&ancestor_blocks)).into())?;
         debug!(target: "engine", elapsed=?exec_time.elapsed(), ?block_number, "Executed block");
         self.consensus.validate_block_post_execution(
             &block,


### PR DESCRIPTION
### Description

This pr is to add `ancestor_blocks` when executing block in new engine. The bsc executor needs ancestor blocks as context when doing live sync.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
