### PR TITLE
fix: unwind_to should be exclusive

### DIFF
--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -317,8 +317,9 @@ where
 
         // First unwind the db tables, until the unwind_to block number. use the walker to unwind
         // HeaderNumbers based on the index in CanonicalHeaders
+        // unwind from the next block number since the unwind_to block is exclusive
         provider.unwind_table_by_walker::<tables::CanonicalHeaders, tables::HeaderNumbers>(
-            input.unwind_to..,
+            (input.unwind_to + 1)..,
         )?;
         provider.unwind_table_by_num::<tables::CanonicalHeaders>(input.unwind_to)?;
         provider.unwind_table_by_num::<tables::HeaderTerminalDifficulties>(input.unwind_to)?;


### PR DESCRIPTION
### Description

While unwinding with `unwind_table_by_walker`, the range passed is inclusive. To ensure the `unwind_to` block is preserved, we adjust the range to start from `unwind_to + 1
`
### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
