### PR TITLE
chore: add debug logs when state root mismatched

### DIFF
--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -261,6 +261,13 @@ impl AppendableChain {
                 (state_root, None)
             };
             if block.state_root != state_root {
+                tracing::debug!(
+                    target: "blockchain_tree::chain",
+                    number = block.number,
+                    hash = %block_hash,
+                    receipts = ?&initial_execution_outcome.receipts,
+                    "Mismatched state root"
+                );
                 return Err(ConsensusError::BodyStateRootDiff(
                     GotExpected { got: state_root, expected: block.state_root }.into(),
                 )

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1780,6 +1780,13 @@ where
         let (state_root, trie_output) =
             state_provider.state_root_with_updates(hashed_state.clone())?;
         if state_root != block.state_root {
+            debug!(
+                target: "engine",
+                number = block.number,
+                hash = %block_hash,
+                receipts = ?output.receipts,
+                "Mismatched state root"
+            );
             return Err(ConsensusError::BodyStateRootDiff(
                 GotExpected { got: state_root, expected: block.state_root }.into(),
             )

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -34,7 +34,7 @@ Please include the following information in your report:
  * The debug logs from __the same time period__. To find the default location for these logs, run:
    `reth --help | grep -A 4 'log.file.directory'`
 
-Once you have this information, please submit a github issue at https://github.com/paradigmxyz/reth/issues/new
+Once you have this information, please submit a github issue at https://github.com/bnb-chain/reth/issues/new
 "#;
 
 /// The default threshold (in number of blocks) for switching from incremental trie building


### PR DESCRIPTION
### Description

This pr is to add debug logs to print block receipts when state root mismatched error happened

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
