### PR TITLE
fix: writes sidecars to static files when saving blocks

### DIFF
--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -825,7 +825,7 @@ mod tests {
 
                         for block_number in 0..=progress.number {
                             static_file_producer_sc.append_sidecars(
-                                Default::default(),
+                                &Default::default(),
                                 block_number,
                                 &blocks
                                     .get(block_number as usize)

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -255,9 +255,9 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
                     // Write sidecars
                     let sidecars = block.sidecars.unwrap_or_default();
                     static_file_producer_sc.append_sidecars(
-                        sidecars,
+                        &sidecars,
                         block_number,
-                        block.header.hash(),
+                        &block.header.hash(),
                     )?;
 
                     // Write ommers if any
@@ -284,9 +284,9 @@ impl<DB: Database, D: BodyDownloader> Stage<DB> for BodyStage<D> {
                 BlockResponse::Empty(header) => {
                     // Write empty sidecars
                     static_file_producer_sc.append_sidecars(
-                        Default::default(),
+                        &Default::default(),
                         block_number,
-                        header.hash(),
+                        &header.hash(),
                     )?;
                 }
             };
@@ -827,7 +827,10 @@ mod tests {
                             static_file_producer_sc.append_sidecars(
                                 Default::default(),
                                 block_number,
-                                blocks.get(block_number as usize).map(|b| b.header.hash()).unwrap(),
+                                &blocks
+                                    .get(block_number as usize)
+                                    .map(|b| b.header.hash())
+                                    .unwrap(),
                             )?;
                             tx.put::<tables::Sidecars>(block_number, Default::default())?;
                         }

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -185,11 +185,11 @@ impl TestStageDB {
             let segment_header = writer.user_header();
             if segment_header.block_end().is_none() && segment_header.expected_block_start() == 0 {
                 for block_number in 0..block_number {
-                    writer.append_sidecars(Default::default(), block_number, &B256::ZERO)?;
+                    writer.append_sidecars(&Default::default(), block_number, &B256::ZERO)?;
                 }
             }
 
-            writer.append_sidecars(Default::default(), block_number, &hash)?;
+            writer.append_sidecars(&Default::default(), block_number, &hash)?;
         } else {
             tx.put::<tables::Sidecars>(block_number, Default::default())?;
         }

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -185,11 +185,11 @@ impl TestStageDB {
             let segment_header = writer.user_header();
             if segment_header.block_end().is_none() && segment_header.expected_block_start() == 0 {
                 for block_number in 0..block_number {
-                    writer.append_sidecars(Default::default(), block_number, B256::ZERO)?;
+                    writer.append_sidecars(Default::default(), block_number, &B256::ZERO)?;
                 }
             }
 
-            writer.append_sidecars(Default::default(), block_number, hash)?;
+            writer.append_sidecars(Default::default(), block_number, &hash)?;
         } else {
             tx.put::<tables::Sidecars>(block_number, Default::default())?;
         }

--- a/crates/static-file/static-file/src/segments/sidecars.rs
+++ b/crates/static-file/static-file/src/segments/sidecars.rs
@@ -43,7 +43,7 @@ impl<DB: Database> Segment<DB> for Sidecars {
             debug_assert_eq!(header_block, canonical_header_block);
 
             let _static_file_block =
-                static_file_writer.append_sidecars(sidecar, header_block, canonical_header)?;
+                static_file_writer.append_sidecars(&sidecar, header_block, &canonical_header)?;
             debug_assert_eq!(_static_file_block, header_block);
         }
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -296,7 +296,7 @@ pub fn insert_genesis_header<DB: Database>(
 
             // skip the zero block index
             let mut writer = static_file_provider.latest_writer(StaticFileSegment::Sidecars)?;
-            writer.append_sidecars(Default::default(), 0, B256::ZERO)?;
+            writer.append_sidecars(&Default::default(), 0, &B256::ZERO)?;
         }
         Ok(Some(_)) => {}
         Err(e) => return Err(e),

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -742,7 +742,7 @@ impl StaticFileProvider {
             // append empty sidecars
             for block_number in range_start..=checkpoint_block_number {
                 let hash = provider.block_hash(block_number)?.unwrap_or_default();
-                writer.append_sidecars(Default::default(), block_number, hash)?;
+                writer.append_sidecars(&Default::default(), block_number, &hash)?;
             }
             writer.commit()?;
             self.writers.set_writer(segment, Some(writer));

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -194,7 +194,7 @@ mod tests {
             for sidecars in sidecars_set.clone() {
                 let block_number = sidecars[0].block_number.to();
                 let hash = sidecars[0].block_hash;
-                writer.append_sidecars(sidecars, block_number, hash).unwrap();
+                writer.append_sidecars(&sidecars, block_number, &hash).unwrap();
             }
             writer.commit().unwrap();
         }

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -580,9 +580,9 @@ impl StaticFileProviderRW {
     /// Returns the current [`BlockNumber`] as seen in the static file.
     pub fn append_sidecars(
         &mut self,
-        sidecars: BlobSidecars,
+        sidecars: &BlobSidecars,
         block_number: BlockNumber,
-        hash: BlockHash,
+        hash: &BlockHash,
     ) -> ProviderResult<BlockNumber> {
         let start = Instant::now();
         self.ensure_no_queued_prune()?;


### PR DESCRIPTION
### Description

This PR is to fix an issue where sidecars were not being saved when saving blocks.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
