### PR TITLE
engine: don't skip state root when insert downloaded block

### DIFF
--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1729,7 +1729,7 @@ where
                 let start = Instant::now();
                 match self.blockchain.insert_block_without_senders(
                     block.clone(),
-                    BlockValidationKind::SkipStateRootValidation,
+                    BlockValidationKind::Exhaustive,
                 ) {
                     Ok(status) => {
                         match status {

--- a/crates/consensus/beacon/src/engine/mod.rs
+++ b/crates/consensus/beacon/src/engine/mod.rs
@@ -1727,10 +1727,10 @@ where
             BlockchainTreeAction::InsertDownloadedPayload { block } => {
                 let downloaded_num_hash = block.num_hash();
                 let start = Instant::now();
-                match self.blockchain.insert_block_without_senders(
-                    block.clone(),
-                    BlockValidationKind::Exhaustive,
-                ) {
+                match self
+                    .blockchain
+                    .insert_block_without_senders(block.clone(), BlockValidationKind::Exhaustive)
+                {
                     Ok(status) => {
                         match status {
                             InsertPayloadOk::Inserted(BlockStatus::Valid(_)) => {


### PR DESCRIPTION
### Description

Enable parallel state root calculation on the BSC network for the old engine.

### Rationale

Parallel state root calculation can significantly improve performance.

### Example

NA

### Changes

Notable changes: 
* Enable parallel state root calculation on the BSC network for the old engine

### Potential Impacts
* NA
