### PR TITLE
chore: use the official alloy-chains dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,8 +109,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.18"
-source = "git+https://github.com/bnb-chain/alloy-chains-rs.git?tag=v1.0.0#b7c5379cf47345181f8dce350acafb958f47152a"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805f7a974de5804f5c053edc6ca43b20883bdd3a733b3691200ae3a4b454a2db"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -4202,7 +4203,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ members = [
     "examples/txpool-tracing/",
     "examples/custom-rlpx-subprotocol",
     "testing/ef-tests/",
-    "testing/testing-utils", 
+    "testing/testing-utils",
 ]
 default-members = ["bin/reth"]
 
@@ -338,7 +338,7 @@ reth-network-p2p = { path = "crates/net/p2p" }
 reth-nippy-jar = { path = "crates/storage/nippy-jar" }
 reth-node-api = { path = "crates/node/api" }
 reth-node-builder = { path = "crates/node/builder" }
-reth-node-bsc= { path = "crates/bsc/node" }
+reth-node-bsc = { path = "crates/bsc/node" }
 reth-node-core = { path = "crates/node/core" }
 reth-node-ethereum = { path = "crates/ethereum/node" }
 reth-node-events = { path = "crates/node/events" }
@@ -399,7 +399,7 @@ revm-primitives = { version = "7.1.0", features = [
 revm-inspectors = "0.5"
 
 # eth
-alloy-chains = "0.1.18"
+alloy-chains = "0.1.33"
 alloy-primitives = "0.7.2"
 alloy-dyn-abi = "0.7.2"
 alloy-json-abi = "0.7.2"
@@ -464,9 +464,9 @@ serde_with = "3.3.0"
 humantime = "2.1"
 humantime-serde = "1.1"
 rand = "0.8.5"
-rustc-hash = {  version = "2.0", default-features = false }
+rustc-hash = { version = "2.0", default-features = false }
 schnellru = "0.2"
-strum = {  version = "0.26", default-features = false }
+strum = { version = "0.26", default-features = false }
 strum_macros = "=0.26.4"
 rayon = "1.7"
 itertools = "0.13"
@@ -560,7 +560,6 @@ revm = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.2" }
 revm-interpreter = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.2" }
 revm-precompile = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.2" }
 revm-primitives = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.2" }
-alloy-chains = { git = "https://github.com/bnb-chain/alloy-chains-rs.git", tag = "v1.0.0" }
 alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }
 alloy-consensus = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }
 alloy-eips = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.0" }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -41,7 +41,7 @@ use reth_network_peers::{opbnb_mainnet_nodes, opbnb_testnet_nodes};
 #[cfg(feature = "bsc")]
 pub static BSC_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
     ChainSpec {
-        chain: Chain::from_named(NamedChain::BNBSmartChain),
+        chain: Chain::from_named(NamedChain::BinanceSmartChain),
         genesis: serde_json::from_str(include_str!("../res/genesis/bsc_mainnet.json"))
             .expect("Can't deserialize BSC Mainnet genesis json"),
         genesis_hash: Some(b256!(
@@ -61,7 +61,7 @@ pub static BSC_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
 #[cfg(feature = "bsc")]
 pub static BSC_TESTNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
     ChainSpec {
-        chain: Chain::from_named(NamedChain::BNBSmartChainTestnet),
+        chain: Chain::from_named(NamedChain::BinanceSmartChainTestnet),
         genesis: serde_json::from_str(include_str!("../res/genesis/bsc_testnet.json"))
             .expect("Can't deserialize BSC Testnet genesis json"),
         genesis_hash: Some(b256!(
@@ -842,9 +842,9 @@ impl ChainSpec {
             C::BaseGoerli | C::BaseSepolia => Some(base_testnet_nodes()),
             C::OptimismSepolia | C::OptimismGoerli | C::OptimismKovan => Some(op_testnet_nodes()),
             #[cfg(feature = "bsc")]
-            C::BNBSmartChain => Some(bsc_mainnet_nodes()),
+            C::BinanceSmartChain => Some(bsc_mainnet_nodes()),
             #[cfg(feature = "bsc")]
-            C::BNBSmartChainTestnet => Some(bsc_testnet_nodes()),
+            C::BinanceSmartChainTestnet => Some(bsc_testnet_nodes()),
             #[cfg(all(feature = "optimism", feature = "opbnb"))]
             C::OpBNBTestnet => Some(opbnb_testnet_nodes()),
             #[cfg(all(feature = "optimism", feature = "opbnb"))]

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -284,7 +284,7 @@ mod tests {
         let expected = hex!("f850423884024190faa0f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27ba00d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5bc6845d43d2fd80");
         let status = Status {
             version: EthVersion::Eth66 as u8,
-            chain: Chain::from_named(NamedChain::BNBSmartChain),
+            chain: Chain::from_named(NamedChain::BinanceSmartChain),
             total_difficulty: U256::from(37851386u64),
             blockhash: B256::from_str(
                 "f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b",
@@ -307,7 +307,7 @@ mod tests {
         let data = hex!("f850423884024190faa0f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27ba00d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5bc6845d43d2fd80");
         let expected = Status {
             version: EthVersion::Eth66 as u8,
-            chain: Chain::from_named(NamedChain::BNBSmartChain),
+            chain: Chain::from_named(NamedChain::BinanceSmartChain),
             total_difficulty: U256::from(37851386u64),
             blockhash: B256::from_str(
                 "f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b",


### PR DESCRIPTION
### Description

Use the official alloy-chains dep.  It supports BSC and opBNB chains now.

However, the chain name `BinanceSmartChain` is kept for backward compatibility. We need to tolerate this for now. 

https://github.com/alloy-rs/chains/pull/87/files#diff-2b5280aeddf870a544b65053acab57b69155bbffe31fafe30e1e61b8e98bf6b3R89 

### Rationale
Streamline

### Example

NA

### Changes

Notable changes: 
* chain specs

### Potential Impacts
* NA
