### PR TITLE
fix: enable skip_state_root_validation on new engine

### DIFF
--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -78,6 +78,7 @@ where
         tree_config: TreeConfig,
         invalid_block_hook: Box<dyn InvalidBlockHook>,
         sync_metrics_tx: MetricEventsSender,
+        skip_state_root_validation: bool,
     ) -> Self {
         let downloader = BasicBlockDownloader::new(client, consensus.clone());
 
@@ -97,6 +98,7 @@ where
             canonical_in_memory_state,
             tree_config,
             invalid_block_hook,
+            skip_state_root_validation,
         );
 
         let engine_handler = EngineApiRequestHandler::new(to_tree_tx, from_tree);
@@ -209,6 +211,7 @@ mod tests {
             TreeConfig::default(),
             Box::new(NoopInvalidBlockHook::default()),
             sync_metrics_tx,
+            false,
         );
     }
 }

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -242,6 +242,7 @@ where
                     engine_tree_config,
                     ctx.invalid_block_hook()?,
                     ctx.sync_metrics_tx(),
+                    ctx.node_config().skip_state_root_validation,
                 );
                 eth_service
             }
@@ -273,6 +274,7 @@ where
                     engine_tree_config,
                     ctx.invalid_block_hook()?,
                     ctx.sync_metrics_tx(),
+                    ctx.node_config().skip_state_root_validation,
                 );
                 eth_service
             }


### PR DESCRIPTION
### Description

enable skip_state_root_validation on new engine

### Rationale

Adapt `--optimize.skip-state-root-validation` feature on new engine

### Example

```bash
bsc-reth node --datadir ./.local --chain bsc-testnet --http --http.port 8545 \
   --optimize.skip-state-root-validation --engine.experimental -vvvv
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
