### PR TITLE
fix: execution error due to int conversion

### DIFF
--- a/crates/bsc/consensus/src/system_tx.rs
+++ b/crates/bsc/consensus/src/system_tx.rs
@@ -85,7 +85,7 @@ impl Parlia {
         })
     }
 
-    pub fn distribute_to_system(&self, system_reward: u64) -> Transaction {
+    pub fn distribute_to_system(&self, system_reward: u128) -> Transaction {
         Transaction::Legacy(TxLegacy {
             chain_id: Some(self.chain_spec.chain.id()),
             nonce: 0,
@@ -97,7 +97,7 @@ impl Parlia {
         })
     }
 
-    pub fn distribute_to_validator(&self, address: Address, block_reward: u64) -> Transaction {
+    pub fn distribute_to_validator(&self, address: Address, block_reward: u128) -> Transaction {
         let function = self.validator_abi.function("deposit").unwrap().first().unwrap();
         let input = function.abi_encode_input(&[DynSolValue::from(address)]).unwrap();
 

--- a/crates/bsc/evm/src/post_execution.rs
+++ b/crates/bsc/evm/src/post_execution.rs
@@ -344,7 +344,7 @@ where
             let reward_to_system = block_reward >> SYSTEM_REWARD_PERCENT;
             if reward_to_system > 0 {
                 self.transact_system_tx(
-                    self.parlia().distribute_to_system(reward_to_system.try_into().unwrap()),
+                    self.parlia().distribute_to_system(reward_to_system),
                     validator,
                     system_txs,
                     receipts,
@@ -357,7 +357,7 @@ where
         }
 
         self.transact_system_tx(
-            self.parlia().distribute_to_validator(validator, block_reward.try_into().unwrap()),
+            self.parlia().distribute_to_validator(validator, block_reward),
             validator,
             system_txs,
             receipts,


### PR DESCRIPTION
### Description

fix execution error due to int conversion

### Rationale

```
thread 'tokio-runtime-worker' panicked at /app/crates/bsc/evm/src/post_execution.rs:360:86:
called `Result::unwrap()` on an `Err` value: TryFromIntError(())
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2024-09-30T10:49:26.092517Z ERROR Critical task `pipeline task` panicked: `called `Result::unwrap()` on an `Err` value: TryFromIntError(())`
2024-09-30T10:49:26.092551Z ERROR backfill sync task dropped err=channel closed
2024-09-30T10:49:26.092578Z ERROR Fatal error in consensus engine
2024-09-30T10:49:26.092908Z ERROR shutting down due to error
Error: Critical task `pipeline task` panicked: `called `Result::unwrap()` on an `Err` value: TryFromIntError(())`

Location:
    /app/crates/cli/runner/src/lib.rs:161:32
```

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* bsc

### Potential Impacts
* bug fix