### PR TITLE
chore: fix widnwos binary build from ci

### DIFF
--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -153,7 +153,6 @@ pub struct NetworkArgs {
     /// Name of network interface used to communicate with peers.
     ///
     /// If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
-    #[cfg(not(target_os = "windows"))]
     #[arg(long = "net-if.experimental", conflicts_with = "addr", value_name = "IF_NAME")]
     pub net_if: Option<String>,
 }
@@ -161,7 +160,6 @@ pub struct NetworkArgs {
 impl NetworkArgs {
     /// Returns the resolved IP address.
     pub fn resolved_addr(&self) -> IpAddr {
-        #[cfg(not(target_os = "windows"))]
         if let Some(ref if_name) = self.net_if {
             let if_name = if if_name.is_empty() { DEFAULT_NET_IF_NAME } else { if_name };
             return match reth_net_nat::net_if::resolve_net_if_ip(if_name) {


### PR DESCRIPTION
### Description

fix widnwos binary build from ci

### Rationale

```
error[E0432]: unresolved import `net_if`
  --> crates/net/nat/src/lib.rs:17:9
   |
17 | pub use net_if::{NetInterfaceError, DEFAULT_NET_IF_NAME};
   |         ^^^^^^ use of undeclared crate or module `net_if`

warning: extern crate `if_addrs` is unused in crate `reth_net_nat`
   |
   = help: remove the dependency or add `use if_addrs as _;` to the crate root
note: the lint level is defined here
  --> crates/net/nat/src/lib.rs:12:29
   |
12 | #![cfg_attr(not(test), warn(unused_crate_dependencies))]
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^

   Compiling reth-ecies v1.0.5 (/project/crates/net/ecies)
```

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
