### PR TITLE
ci: fix windows build and add build-check job

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,67 @@
+name: build-check
+
+on:
+    pull_request:
+      branches: [ main, develop ]
+
+env:
+  CARGO_TERM_COLOR: always
+  TOOL_CHAIN: "1.81"
+
+jobs:
+  extract-version:
+    name: extract version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version
+        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
+        id: extract_version
+    outputs:
+      VERSION: ${{ steps.extract_version.outputs.VERSION }}
+
+  build:
+    name: build release
+    runs-on: ${{ matrix.configs.os }}
+    needs: extract-version
+    strategy:
+      matrix:
+        configs:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-20.04
+            profile: maxperf
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-20.04
+            profile: maxperf
+          - target: x86_64-apple-darwin
+            os: macos-13
+            profile: maxperf
+          - target: aarch64-apple-darwin
+            os: macos-14
+            profile: maxperf
+          - target: x86_64-pc-windows-gnu
+            os: ubuntu-20.04
+            profile: maxperf
+        build:
+          - command: op-build
+            binary: op-reth
+          - command: bsc-build
+            binary: bsc-reth
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.configs.target }}
+          toolchain: ${{ env.TOOL_CHAIN }}
+      - uses: taiki-e/install-action@cross
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Apple M1 setup
+        if: matrix.configs.target == 'aarch64-apple-darwin'
+        run: |
+          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
+
+      - name: Build Reth
+        run: make PROFILE=${{ matrix.configs.profile }} ${{ matrix.build.command }}-${{ matrix.configs.target }}

--- a/crates/net/nat/src/net_if.rs
+++ b/crates/net/nat/src/net_if.rs
@@ -1,7 +1,5 @@
 //! IP resolution on non-host Docker network.
 
-#![cfg(not(target_os = "windows"))]
-
 use std::{io, net::IpAddr};
 
 /// The 'eth0' interface tends to be the default interface that docker containers use to
@@ -20,7 +18,6 @@ pub enum NetInterfaceError {
 }
 
 /// Reads IP of OS interface with given name, if exists.
-#[cfg(not(target_os = "windows"))]
 pub fn resolve_net_if_ip(if_name: &str) -> Result<IpAddr, NetInterfaceError> {
     match if_addrs::get_if_addrs() {
         Ok(ifs) => {

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -153,7 +153,6 @@ pub struct NetworkArgs {
     /// Name of network interface used to communicate with peers.
     ///
     /// If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
-    #[cfg(not(target_os = "windows"))]
     #[arg(long = "net-if.experimental", conflicts_with = "addr", value_name = "IF_NAME")]
     pub net_if: Option<String>,
 }
@@ -161,7 +160,6 @@ pub struct NetworkArgs {
 impl NetworkArgs {
     /// Returns the resolved IP address.
     pub fn resolved_addr(&self) -> IpAddr {
-        #[cfg(not(target_os = "windows"))]
         if let Some(ref if_name) = self.net_if {
             let if_name = if if_name.is_empty() { DEFAULT_NET_IF_NAME } else { if_name };
             return match reth_net_nat::net_if::resolve_net_if_ip(if_name) {


### PR DESCRIPTION
### Description

1. fix widnwos binary build from ci
2. add a ci job for binary build to check whether the binary file can be built normally.

### Rationale

```
error[E0432]: unresolved import `net_if`
  --> crates/net/nat/src/lib.rs:17:9
   |
17 | pub use net_if::{NetInterfaceError, DEFAULT_NET_IF_NAME};
   |         ^^^^^^ use of undeclared crate or module `net_if`

warning: extern crate `if_addrs` is unused in crate `reth_net_nat`
   |
   = help: remove the dependency or add `use if_addrs as _;` to the crate root
note: the lint level is defined here
  --> crates/net/nat/src/lib.rs:12:29
   |
12 | #![cfg_attr(not(test), warn(unused_crate_dependencies))]
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^

   Compiling reth-ecies v1.0.5 (/project/crates/net/ecies)
```

### Example

n/a

### Changes

Notable changes: 
* no

### Potential Impacts
* no
