### PR TITLE
feat: enable prefetch on the new engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8218,6 +8218,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "reth-trie-parallel",
+ "reth-trie-prefetch",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/blockchain-tree/src/chain.rs
+++ b/crates/blockchain-tree/src/chain.rs
@@ -30,7 +30,6 @@ use std::{
     clone::Clone,
     collections::BTreeMap,
     ops::{Deref, DerefMut},
-    sync::Arc,
     time::Instant,
 };
 
@@ -231,14 +230,9 @@ impl AppendableChain {
 
         let initial_execution_outcome = ExecutionOutcome::from((state, block.number));
 
-        // stop the prefetch task.
-        if let Some(interrupt_tx) = interrupt_tx {
-            let _ = interrupt_tx.send(());
-        }
-
         // check state root if the block extends the canonical chain __and__ if state root
         // validation was requested.
-        if block_validation_kind.is_exhaustive() {
+        let result = if block_validation_kind.is_exhaustive() {
             // calculate and check state root
             let start = Instant::now();
             let (state_root, trie_updates) = if block_attachment.is_canonical() {
@@ -283,7 +277,14 @@ impl AppendableChain {
             Ok((initial_execution_outcome, trie_updates))
         } else {
             Ok((initial_execution_outcome, None))
-        }
+        };
+
+        // stop the prefetch task.
+        if let Some(interrupt_tx) = interrupt_tx {
+            let _ = interrupt_tx.send(());
+        };
+
+        result
     }
 
     /// Validate and execute the given block, and append it to this chain.
@@ -356,18 +357,11 @@ impl AppendableChain {
         let (interrupt_tx, interrupt_rx) = tokio::sync::oneshot::channel();
 
         let mut trie_prefetch = TriePrefetch::new();
-        let consistent_view = if let Ok(view) =
-            ConsistentDbView::new_with_latest_tip(externals.provider_factory.clone())
-        {
-            view
-        } else {
-            tracing::debug!("Failed to create consistent view for trie prefetch");
-            return (None, None)
-        };
+        let provider_factory = externals.provider_factory.clone();
 
         tokio::spawn({
             async move {
-                trie_prefetch.run(Arc::new(consistent_view), prefetch_rx, interrupt_rx).await;
+                trie_prefetch.run(provider_factory, prefetch_rx, interrupt_rx).await;
             }
         });
 

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -80,6 +80,7 @@ where
         invalid_block_hook: Box<dyn InvalidBlockHook>,
         sync_metrics_tx: MetricEventsSender,
         skip_state_root_validation: bool,
+        enable_prefetch: bool,
     ) -> Self {
         let engine_kind =
             if chain_spec.is_optimism() { EngineApiKind::OpStack } else { EngineApiKind::Ethereum };
@@ -104,6 +105,7 @@ where
             invalid_block_hook,
             engine_kind,
             skip_state_root_validation,
+            enable_prefetch,
         );
 
         let engine_handler = EngineApiRequestHandler::new(to_tree_tx, from_tree);
@@ -216,6 +218,7 @@ mod tests {
             TreeConfig::default(),
             Box::new(NoopInvalidBlockHook::default()),
             sync_metrics_tx,
+            false,
             false,
         );
     }

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -33,6 +33,7 @@ reth-stages-api.workspace = true
 reth-tasks.workspace = true
 reth-trie.workspace = true
 reth-trie-parallel.workspace = true
+reth-trie-prefetch.workspace = true
 
 # alloy
 alloy-primitives.workspace = true

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -237,6 +237,7 @@ where
                     ctx.invalid_block_hook()?,
                     ctx.sync_metrics_tx(),
                     ctx.node_config().skip_state_root_validation,
+                    ctx.node_config().enable_prefetch,
                 );
                 eth_service
             }
@@ -271,6 +272,7 @@ where
                     ctx.invalid_block_hook()?,
                     ctx.sync_metrics_tx(),
                     ctx.node_config().skip_state_root_validation,
+                    ctx.node_config().enable_prefetch,
                 );
                 eth_service
             }

--- a/crates/trie/prefetch/src/lib.rs
+++ b/crates/trie/prefetch/src/lib.rs
@@ -7,8 +7,11 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+pub use prefetch::TriePrefetch;
 pub use reth_trie_parallel::StorageRootTargets;
 
+/// Trie prefetch stats.
+pub mod stats;
+
 /// Implementation of trie prefetch.
-mod prefetch;
-pub use prefetch::TriePrefetch;
+pub mod prefetch;

--- a/crates/trie/prefetch/src/stats.rs
+++ b/crates/trie/prefetch/src/stats.rs
@@ -1,0 +1,45 @@
+/// Trie stats.
+#[derive(Clone, Copy, Debug)]
+pub struct TriePrefetchStats {
+    branches_prefetched: u64,
+    leaves_prefetched: u64,
+}
+
+impl TriePrefetchStats {
+    /// The number of added branch nodes for which we prefetched.
+    pub const fn branches_prefetched(&self) -> u64 {
+        self.branches_prefetched
+    }
+
+    /// The number of added leaf nodes for which we prefetched.
+    pub const fn leaves_prefetched(&self) -> u64 {
+        self.leaves_prefetched
+    }
+}
+
+/// Trie metrics tracker.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct TriePrefetchTracker {
+    branches_prefetched: u64,
+    leaves_prefetched: u64,
+}
+
+impl TriePrefetchTracker {
+    /// Increment the number of branches prefetched.
+    pub fn inc_branches(&mut self, num: u64) {
+        self.branches_prefetched += num;
+    }
+
+    /// Increment the number of leaves prefetched.
+    pub fn inc_leaves(&mut self, num: u64) {
+        self.leaves_prefetched += num;
+    }
+
+    /// Called when prefetch is finished to return trie prefetch statistics.
+    pub const fn finish(self) -> TriePrefetchStats {
+        TriePrefetchStats {
+            branches_prefetched: self.branches_prefetched,
+            leaves_prefetched: self.leaves_prefetched,
+        }
+    }
+}


### PR DESCRIPTION
### Description

Enable trie prefetch on the new engine and implement some optimizations.

### Rationale

There are two optimizations:  
1. Previously, the prefetch feature did not affect the old engine using parallel state root computation. We should prefetch the account tree and storage trees concurrently to ensure that the account tree nodes are loaded before computing the state root. This optimization can reduce the state root computation time of the old engine by about 28%.

2. Enable prefetching on the new engine, this optimization can reduce the state root computation time of the new engine by about 20%.

### Example

NA

### Changes

Notable changes: 
* NA

### Potential Impacts
* Improve state root computation performance.
