### PR TITLE
chore: update the default threshold of merkle rebuild to 50k

### DIFF
--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -37,7 +37,7 @@ Once you have this information, please submit a github issue at https://github.c
 
 /// The default threshold (in number of blocks) for switching from incremental trie building
 /// of changes to whole rebuild.
-pub const MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD: u64 = 5_000;
+pub const MERKLE_STAGE_DEFAULT_CLEAN_THRESHOLD: u64 = 50_000;
 
 /// The merkle hashing stage uses input from
 /// [`AccountHashingStage`][crate::stages::AccountHashingStage] and


### PR DESCRIPTION
### Description

Update the threshold for trie rebuilding from 5_000 to 50_000.

### Rationale

5k is too small  - trie rebuilding needs a lot of time.

### Example

NA

### Changes

Notable changes: 
* trie rebuilding threshold
