### PR TITLE
chore: bump revm to 1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "14.0.3"
-source = "git+https://github.com/bnb-chain/revm?rev=0978bcb4189c547e7b71b2f11389ff2214fbe319#0978bcb4189c547e7b71b2f11389ff2214fbe319"
+source = "git+https://github.com/bnb-chain/revm?rev=v1.0.4#0978bcb4189c547e7b71b2f11389ff2214fbe319"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -10379,7 +10379,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "10.0.3"
-source = "git+https://github.com/bnb-chain/revm?rev=0978bcb4189c547e7b71b2f11389ff2214fbe319#0978bcb4189c547e7b71b2f11389ff2214fbe319"
+source = "git+https://github.com/bnb-chain/revm?rev=v1.0.4#0978bcb4189c547e7b71b2f11389ff2214fbe319"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "11.0.3"
-source = "git+https://github.com/bnb-chain/revm?rev=0978bcb4189c547e7b71b2f11389ff2214fbe319#0978bcb4189c547e7b71b2f11389ff2214fbe319"
+source = "git+https://github.com/bnb-chain/revm?rev=v1.0.4#0978bcb4189c547e7b71b2f11389ff2214fbe319"
 dependencies = [
  "alloy-rlp",
  "aurora-engine-modexp",
@@ -10416,7 +10416,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "10.0.0"
-source = "git+https://github.com/bnb-chain/revm?rev=0978bcb4189c547e7b71b2f11389ff2214fbe319#0978bcb4189c547e7b71b2f11389ff2214fbe319"
+source = "git+https://github.com/bnb-chain/revm?rev=v1.0.4#0978bcb4189c547e7b71b2f11389ff2214fbe319"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -615,9 +615,9 @@ tikv-jemallocator = "0.6"
 tracy-client = "0.17.3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bnb-chain/revm", rev = "0978bcb4189c547e7b71b2f11389ff2214fbe319" }
-revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "0978bcb4189c547e7b71b2f11389ff2214fbe319" }
-revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "0978bcb4189c547e7b71b2f11389ff2214fbe319" }
+revm = { git = "https://github.com/bnb-chain/revm", rev = "v1.0.4" }
+revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "v1.0.4" }
+revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "v1.0.4" }
 alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", rev = "718060680134e6bb40d97d3c6fb56fd1950ced36" }
 alloy-consensus = { git = "https://github.com/bnb-chain/alloy", rev = "718060680134e6bb40d97d3c6fb56fd1950ced36" }
 alloy-eips = { git = "https://github.com/bnb-chain/alloy", rev = "718060680134e6bb40d97d3c6fb56fd1950ced36" }


### PR DESCRIPTION
### Description

Bump revm to v1.0.4 formal release.

### Rationale

For release.

### Example

NA

### Changes

Notable changes: 
* Cargo.toml
