### PR TITLE
chore: update the default `MerkleConfig`

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -309,7 +309,7 @@ pub struct MerkleConfig {
 
 impl Default for MerkleConfig {
     fn default() -> Self {
-        Self { clean_threshold: 5_000 }
+        Self { clean_threshold: 50_000 }
     }
 }
 


### PR DESCRIPTION
### Description

This pr is to update the default threshold of merkle rebuild to 50k

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
