### PR TITLE
fix: bsc panic in fullnode mode

### DIFF
--- a/crates/bsc/engine/src/task.rs
+++ b/crates/bsc/engine/src/task.rs
@@ -421,21 +421,20 @@ impl<
                 }
                 for header in disconnected_headers {
                     storage.insert_new_header(header.clone());
-                    let result =
-                        fork_choice_tx.send(ForkChoiceMessage::NewHeader(NewHeaderEvent {
-                            header: header.clone(),
-                            // if the pipeline sync is true, the fork choice will not use the safe
-                            // and finalized hash.
-                            // this can make Block Sync Engine to use pipeline sync mode.
-                            pipeline_sync,
-                            local_header: latest_unsafe_header.clone(),
-                        }));
-                    if result.is_err() {
-                        error!(target: "consensus::parlia", "Failed to send new block event to
-                    fork choice");
-                    }
                 }
                 drop(storage);
+                let result = fork_choice_tx.send(ForkChoiceMessage::NewHeader(NewHeaderEvent {
+                    header: sealed_header.clone(),
+                    // if the pipeline sync is true, the fork choice will not use the safe
+                    // and finalized hash.
+                    // this can make Block Sync Engine to use pipeline sync mode.
+                    pipeline_sync,
+                    local_header: latest_unsafe_header.clone(),
+                }));
+                if result.is_err() {
+                    error!(target: "consensus::parlia", "Failed to send new block event to
+                fork choice");
+                }
 
                 let result = chain_tracker_tx.send(ForkChoiceMessage::NewHeader(NewHeaderEvent {
                     header: sealed_header.clone(),


### PR DESCRIPTION
### Description

fix: bsc panic in fullnode mode

### Rationale

```
{"timestamp":"2024-11-08T16:34:53.355266Z","level":"DEBUG","fields":{"message":"Inserted block","block_number":"43834321","actions":"[(InsertCanonicalHeaders, 75.108µs), (InsertHeaders, 28.324µs), (InsertHeaderNumbers, 45.012µs), (GetParentTD, 533ns), (InsertHeaderTerminalDifficulties, 18.363µs), (GetNextTxNum, 6.687µs), (InsertTransactionSenders, 0ns), (InsertTransactions, 1.780118ms), (InsertTransactionHashNumbers, 161.529585ms), (InsertBlockSidecars, 143.74297ms), (InsertBlockBodyIndices, 41.23µs), (InsertTransactionBlocks, 29.447µs)]"},"target":"providers::db"}
{"timestamp":"2024-11-08T16:34:53.355302Z","level":"DEBUG","fields":{"message":"Writing headers and transactions."},"target":"provider::storage_writer"}
{"timestamp":"2024-11-08T16:34:53.355581Z","level":"ERROR","fields":{"message":"Persistence service failed","err":"ProviderError(UnexpectedStaticFileBlockNumber(Headers, 43834321, 43834318))"},"target":"engine::persistence"}
{"timestamp":"2024-11-08T16:34:53.545614Z","level":"DEBUG","fields":{"message":"received no engine message for some time, while waiting for persistence task to complete"},"target":"engine::tree"}
{"timestamp":"2024-11-08T16:34:53.545643Z","level":"ERROR","fields":{"message":"Advancing persistence failed","err":"channel closed"},"target":"engine::tree"}
{"timestamp":"2024-11-08T16:34:53.547768Z","level":"ERROR","fields":{"message":"Fatal error"},"target":"engine::tree","span":{"name":"ChainOrchestrator::poll"},"spans":[{"name":"ChainOrchestrator::poll"}]}
{"timestamp":"2024-11-08T16:34:53.547797Z","level":"DEBUG","fields":{"message":"Event: FatalError"},"target":"reth::cli"}
{"timestamp":"2024-11-08T16:34:53.547816Z","level":"ERROR","fields":{"message":"Fatal error in consensus engine"},"target":"reth::cli"}
{"timestamp":"2024-11-08T16:34:53.549789Z","level":"ERROR","fields":{"message":"shutting down due to error"},"target":"reth::cli"}
{"timestamp":"2024-11-08T16:34:58.550003Z","level":"DEBUG","fields":{"message":"tokio runtime shutdown timed out","err":"timed out waiting on channel"},"target":"reth::cli"}
```

In the original implementation, a forkchoice event was emitted to the sync engine for every update from latest_head to local_finality_head.

However, the local_finality_head in the parlia engine task is read by a separate coroutine (the parlia snapshot reader) and then re-emitted via an fcu event. If this coroutine lags, it can lead to duplicate forkchoice events, which in turn causes repeated import of the same block.

This ultimately results in attempting to import blocks onto a state that has already been pruned (in fullnode mode), causing an abnormal exit.

### Example

n/a

### Changes

Notable changes: 
* parlia engine task

### Potential Impacts
* no
