### PR TITLE
chore: update version of revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "14.0.3"
-source = "git+https://github.com/bnb-chain/revm?rev=0978bcb4189c547e7b71b2f11389ff2214fbe319#0978bcb4189c547e7b71b2f11389ff2214fbe319"
+source = "git+https://github.com/bnb-chain/revm?rev=v1.0.5#a9752c97d2c742d25405a4a9a698f30f5007da6e"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "10.0.3"
-source = "git+https://github.com/bnb-chain/revm?rev=0978bcb4189c547e7b71b2f11389ff2214fbe319#0978bcb4189c547e7b71b2f11389ff2214fbe319"
+source = "git+https://github.com/bnb-chain/revm?rev=v1.0.5#a9752c97d2c742d25405a4a9a698f30f5007da6e"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -10392,7 +10392,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "11.0.3"
-source = "git+https://github.com/bnb-chain/revm?rev=0978bcb4189c547e7b71b2f11389ff2214fbe319#0978bcb4189c547e7b71b2f11389ff2214fbe319"
+source = "git+https://github.com/bnb-chain/revm?rev=v1.0.5#a9752c97d2c742d25405a4a9a698f30f5007da6e"
 dependencies = [
  "alloy-rlp",
  "aurora-engine-modexp",
@@ -10420,7 +10420,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "10.0.0"
-source = "git+https://github.com/bnb-chain/revm?rev=0978bcb4189c547e7b71b2f11389ff2214fbe319#0978bcb4189c547e7b71b2f11389ff2214fbe319"
+source = "git+https://github.com/bnb-chain/revm?rev=v1.0.5#a9752c97d2c742d25405a4a9a698f30f5007da6e"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -615,9 +615,9 @@ tikv-jemallocator = "0.6"
 tracy-client = "0.17.3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bnb-chain/revm", rev = "0978bcb4189c547e7b71b2f11389ff2214fbe319" }
-revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "0978bcb4189c547e7b71b2f11389ff2214fbe319" }
-revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "0978bcb4189c547e7b71b2f11389ff2214fbe319" }
+revm = { git = "https://github.com/bnb-chain/revm", rev = "v1.0.5" }
+revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "v1.0.5" }
+revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "v1.0.5" }
 alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", rev = "718060680134e6bb40d97d3c6fb56fd1950ced36" }
 alloy-consensus = { git = "https://github.com/bnb-chain/alloy", rev = "718060680134e6bb40d97d3c6fb56fd1950ced36" }
 alloy-eips = { git = "https://github.com/bnb-chain/alloy", rev = "718060680134e6bb40d97d3c6fb56fd1950ced36" }


### PR DESCRIPTION
### Description

This pr will update the version of revm to v1.0.5 to fix the gas price checking issue of opBNB.

### Rationale

na

### Example

na 

### Changes

Notable changes: 
* update version of revm

### Potential Impacts

na
