### PR TITLE
fix(witness): branch node children decoding

### DIFF
--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -6,6 +6,8 @@ use alloy_primitives::{
     Address, Bytes, B256, U256,
 };
 use alloy_rlp::EMPTY_STRING_CODE;
+use reth_db::{cursor::DbCursorRW, tables};
+use reth_db_api::transaction::DbTxMut;
 use reth_primitives::{constants::EMPTY_ROOT_HASH, Account, StorageEntry};
 use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
 use reth_trie::{proof::Proof, witness::TrieWitness, HashedPostState, HashedStorage, StateRoot};
@@ -81,6 +83,56 @@ fn includes_nodes_for_destroyed_storage_nodes() {
         .compute(HashedPostState {
             accounts: HashMap::from([(hashed_address, Some(Account::default()))]),
             storages: HashMap::from([(hashed_address, HashedStorage::from_iter(true, []))]), // destroyed
+        })
+        .unwrap();
+    assert!(witness.contains_key(&state_root));
+    for node in multiproof.account_subtree.values() {
+        assert_eq!(witness.get(&keccak256(node)), Some(node));
+    }
+    for node in multiproof.storages.iter().flat_map(|(_, storage)| storage.subtree.values()) {
+        assert_eq!(witness.get(&keccak256(node)), Some(node));
+    }
+}
+
+#[test]
+fn correctly_decodes_branch_node_values() {
+    let factory = create_test_provider_factory();
+    let provider = factory.provider_rw().unwrap();
+
+    let address = Address::random();
+    let hashed_address = keccak256(address);
+    let hashed_slot1 = B256::with_last_byte(1);
+    let hashed_slot2 = B256::with_last_byte(2);
+
+    // Insert account and slots into database
+    provider.insert_account_for_hashing([(address, Some(Account::default()))]).unwrap();
+    let mut hashed_storage_cursor =
+        provider.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+    hashed_storage_cursor
+        .upsert(hashed_address, StorageEntry { key: hashed_slot1, value: U256::from(1) })
+        .unwrap();
+    hashed_storage_cursor
+        .upsert(hashed_address, StorageEntry { key: hashed_slot2, value: U256::from(1) })
+        .unwrap();
+
+    let state_root = StateRoot::from_tx(provider.tx_ref()).root().unwrap();
+    let multiproof = Proof::from_tx(provider.tx_ref())
+        .multiproof(HashMap::from_iter([(
+            hashed_address,
+            HashSet::from_iter([hashed_slot1, hashed_slot2]),
+        )]))
+        .unwrap();
+
+    let witness = TrieWitness::from_tx(provider.tx_ref())
+        .compute(HashedPostState {
+            accounts: HashMap::from([(hashed_address, Some(Account::default()))]),
+            storages: HashMap::from([(
+                hashed_address,
+                HashedStorage::from_iter(
+                    false,
+                    [hashed_slot1, hashed_slot2].map(|hashed_slot| (hashed_slot, U256::from(2))),
+                ),
+            )]),
         })
         .unwrap();
     assert!(witness.contains_key(&state_root));

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -218,9 +218,14 @@ where
                 TrieNode::Branch(branch) => {
                     next_path.push(key[path.len()]);
                     let children = branch_node_children(path.clone(), &branch);
-                    for (child_path, node_hash) in children {
+                    for (child_path, value) in children {
                         if !key.starts_with(&child_path) {
-                            trie_nodes.insert(child_path, Either::Left(node_hash));
+                            let value = if value.len() < B256::len_bytes() {
+                                Either::Right(value.to_vec())
+                            } else {
+                                Either::Left(B256::from_slice(&value[1..]))
+                            };
+                            trie_nodes.insert(child_path, value);
                         }
                     }
                 }
@@ -311,8 +316,13 @@ where
                             match TrieNode::decode(&mut &node[..])? {
                                 TrieNode::Branch(branch) => {
                                     let children = branch_node_children(path, &branch);
-                                    for (child_path, branch_hash) in children {
-                                        hash_builder.add_branch(child_path, branch_hash, false);
+                                    for (child_path, value) in children {
+                                        if value.len() < B256::len_bytes() {
+                                            hash_builder.add_leaf(child_path, value);
+                                        } else {
+                                            let hash = B256::from_slice(&value[1..]);
+                                            hash_builder.add_branch(child_path, hash, false);
+                                        }
                                     }
                                     break
                                 }
@@ -342,14 +352,14 @@ where
 }
 
 /// Returned branch node children with keys in order.
-fn branch_node_children(prefix: Nibbles, node: &BranchNode) -> Vec<(Nibbles, B256)> {
+fn branch_node_children(prefix: Nibbles, node: &BranchNode) -> Vec<(Nibbles, &[u8])> {
     let mut children = Vec::with_capacity(node.state_mask.count_ones() as usize);
     let mut stack_ptr = node.as_ref().first_child_index();
     for index in CHILD_INDEX_RANGE {
         if node.state_mask.is_bit_set(index) {
             let mut child_path = prefix.clone();
             child_path.push(index);
-            children.push((child_path, B256::from_slice(&node.stack[stack_ptr][1..])));
+            children.push((child_path, &node.stack[stack_ptr][..]));
             stack_ptr += 1;
         }
     }


### PR DESCRIPTION
### Description

```
2024-11-15T11:22:04.646774Z DEBUG net: Session established remote_addr=69.67.149.193:60680 client_version=Geth/v1.4.15-ec318b9c/linux-amd64/go1.21.13 peer_id=0xfad8cb973aeabf53e07dfbca9f01c5d4289e35d4c4834b7754a0c54613c02d8714b308c8114e6c6556851526690ec23c42c64d39a1f79ac1afccff506456df8b total_active=100 kind=outgoing peer_enode=enode://fad8cb973aeabf53e07dfbca9f01c5d4289e35d4c4834b7754a0c54613c02d8714b308c8114e6c6556851526690ec23c42c64d39a1f79ac1afccff506456df8b@69.67.149.193:60680
thread 'Tree Task' panicked at crates/trie/trie/src/witness.rs:352:40:
cannot convert a slice of length 30 to FixedBytes<32>
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2024-11-15T11:22:07.120954Z DEBUG consensus::parlia: Latest finalized header finalized_header_number=44029657 finalized_header_hash=0x3c2790f4b2ed6436cd34defc2a3cc3d3625dfb2cb400015dbff7f4c321511380
2024-11-15T11:22:07.121006Z DEBUG consensus::parlia: Latest unsafe header latest_unsafe_header_number=44029659 latest_unsafe_header_hash=0xb0ca4fa5824da3cc6ef3d1cca3bd85dab96a53087a72a159043835b2440f3b37
2024-11-15T11:22:09.006478Z ERROR consensus::parlia: Fork choice update response failed err=RecvError(())
2024-11-15T11:22:09.006499Z ERROR ChainOrchestrator::poll: engine::tree: Fatal error
2024-11-15T11:22:09.006526Z DEBUG reth::cli: Event: FatalError
2024-11-15T11:22:09.006535Z ERROR reth::cli: Fatal error in consensus engine
2024-11-15T11:22:09.006603Z ERROR reth::cli: shutting down due to error
2024-11-15T11:22:14.006823Z DEBUG reth::cli: tokio runtime shutdown timed out err=timed out waiting on channe
```

### Rationale

When encountering an invalid block, a witness is generated. However, an error occurs during this process, causing the node to stop functioning.

The root cause of this issue has been fixed in the upstream version -> https://github.com/paradigmxyz/reth/pull/11599

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
