### PR TITLE
chore: prepare for v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.1.0
+
+This release merges with upstream version v1.1.1, including several bug fixes.
+
+**Key changes:**
+
+* **Compatibility:** This version is compatible with the BSC mainnet, testnet, and opBNB mainnet, testnet.
+* **Bug fixes:**  Several bug fixes are included in this release. For detailed code changes, see this PR: [v1.0.7...v1.1.0](https://github.com/bnb-chain/reth/compare/v1.0.7...v1.1.0)
+
 ## v1.0.7
 
 This is a hotfix release for the BSC/opBNB mainnet and testnet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This release merges with upstream version v1.1.1, including several bug fixes.
 **Key changes:**
 
 * **Compatibility:** This version is compatible with the BSC mainnet, testnet, and opBNB mainnet, testnet.
-* **Bug fixes:**  Several bug fixes are included in this release. For detailed code changes, see this PR: [v1.0.7...v1.1.0](https://github.com/bnb-chain/reth/compare/v1.0.7...v1.1.0)
+* **Bug fixes:**  Several bug fixes are included in this release. For detailed code changes: [v1.0.7...v1.1.0](https://github.com/bnb-chain/reth/compare/v1.0.7...v1.1.0)
 
 ## v1.0.7
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -249,7 +249,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -282,7 +282,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -343,7 +343,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -352,14 +352,14 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
- "alloy-pubsub 0.5.4 (git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444)",
+ "alloy-pubsub 0.5.4 (git+https://github.com/bnb-chain/alloy?tag=v1.0.3)",
  "alloy-rpc-client",
- "alloy-rpc-types-admin 0.5.4 (git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444)",
+ "alloy-rpc-types-admin 0.5.4 (git+https://github.com/bnb-chain/alloy?tag=v1.0.3)",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ws 0.5.4 (git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444)",
+ "alloy-transport-ws 0.5.4 (git+https://github.com/bnb-chain/alloy?tag=v1.0.3)",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -442,14 +442,14 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-pubsub 0.5.4 (git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444)",
+ "alloy-pubsub 0.5.4 (git+https://github.com/bnb-chain/alloy?tag=v1.0.3)",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ws 0.5.4 (git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444)",
+ "alloy-transport-ws 0.5.4 (git+https://github.com/bnb-chain/alloy?tag=v1.0.3)",
  "futures",
  "pin-project",
  "reqwest 0.12.8",
@@ -491,9 +491,9 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
- "alloy-genesis 0.5.4 (git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444)",
+ "alloy-genesis 0.5.4 (git+https://github.com/bnb-chain/alloy?tag=v1.0.3)",
  "alloy-primitives",
  "serde",
  "serde_json",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -746,7 +746,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -797,9 +797,9 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.5.4"
-source = "git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444#b6ca35f241857d220f530b2100581586bac05444"
+source = "git+https://github.com/bnb-chain/alloy?tag=v1.0.3#576cabc6a05f6e483d10d5d16f69a67da5f0b126"
 dependencies = [
- "alloy-pubsub 0.5.4 (git+https://github.com/bnb-chain/alloy?rev=b6ca35f241857d220f530b2100581586bac05444)",
+ "alloy-pubsub 0.5.4 (git+https://github.com/bnb-chain/alloy?tag=v1.0.3)",
  "alloy-transport",
  "futures",
  "http 1.1.0",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "bsc-reth"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "clap",
  "reth-bsc-chainspec",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6026,7 +6026,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7134,7 +7134,7 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reth-auto-seal-consensus"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7237,7 +7237,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7263,7 +7263,7 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7315,7 +7315,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7350,7 +7350,7 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7390,7 +7390,7 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree-api"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7403,7 +7403,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-chainspec"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7422,7 +7422,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-cli"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7465,7 +7465,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-consensus"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7510,7 +7510,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-engine"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
@@ -7560,7 +7560,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-evm"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7590,7 +7590,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-forks"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7601,7 +7601,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-node"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "eyre",
  "futures",
@@ -7637,7 +7637,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-payload-builder"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7664,7 +7664,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-primitives"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7683,7 +7683,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7717,7 +7717,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7740,7 +7740,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
@@ -7753,7 +7753,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "alloy-eips",
@@ -7819,7 +7819,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7828,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7846,7 +7846,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7868,7 +7868,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7896,7 +7896,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7907,7 +7907,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7923,7 +7923,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7946,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7986,7 +7986,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "alloy-primitives",
@@ -8014,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8059,7 +8059,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8086,7 +8086,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8110,7 +8110,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8138,7 +8138,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8175,7 +8175,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -8271,7 +8271,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "reth-execution-types",
@@ -8283,7 +8283,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "futures",
  "pin-project",
@@ -8311,7 +8311,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8361,7 +8361,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8393,7 +8393,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -8405,7 +8405,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8440,7 +8440,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8463,7 +8463,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "clap",
  "eyre",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8488,7 +8488,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8507,7 +8507,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8527,7 +8527,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8553,7 +8553,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8563,7 +8563,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8591,7 +8591,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8616,7 +8616,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8648,7 +8648,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8692,7 +8692,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8741,7 +8741,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8750,7 +8750,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8774,7 +8774,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes 1.7.2",
@@ -8796,7 +8796,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -8817,7 +8817,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "bindgen 0.70.1",
  "cc",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "futures",
  "metrics",
@@ -8836,14 +8836,14 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8857,7 +8857,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8917,7 +8917,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8939,7 +8939,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8975,7 +8975,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9006,7 +9006,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9028,7 +9028,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -9095,7 +9095,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9144,7 +9144,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9191,7 +9191,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "eyre",
  "http 1.1.0",
@@ -9239,7 +9239,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9251,7 +9251,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9271,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9317,7 +9317,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9333,7 +9333,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9372,7 +9372,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -9418,7 +9418,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9452,7 +9452,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9461,7 +9461,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9501,7 +9501,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "reth-codecs",
  "reth-db-api",
@@ -9512,7 +9512,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -9533,7 +9533,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9555,7 +9555,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-rpc-types",
  "reth-chainspec",
@@ -9565,7 +9565,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9610,7 +9610,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9687,7 +9687,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -9716,7 +9716,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9736,7 +9736,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9753,7 +9753,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9826,7 +9826,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -9852,7 +9852,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9872,7 +9872,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9923,7 +9923,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9959,7 +9959,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10002,7 +10002,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10046,7 +10046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.1.0",
@@ -10061,7 +10061,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10076,7 +10076,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types-compat"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10093,7 +10093,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10143,7 +10143,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -10171,7 +10171,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10188,7 +10188,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10210,7 +10210,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10221,7 +10221,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10240,7 +10240,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10252,7 +10252,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10282,7 +10282,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10291,7 +10291,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "clap",
  "eyre",
@@ -10305,7 +10305,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10350,7 +10350,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10379,7 +10379,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10403,7 +10403,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10432,7 +10432,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10459,7 +10459,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-prefetch"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10486,7 +10486,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.0.7"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "17.0.0"
-source = "git+https://github.com/bnb-chain/revm?rev=add28b2bb131aa4a37ab4daf817e46448158dfc8#add28b2bb131aa4a37ab4daf817e46448158dfc8"
+source = "git+https://github.com/bnb-chain/revm?tag=v1.0.6#d66170e712460ae766fc26a063f106658ce33e9d"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "13.0.0"
-source = "git+https://github.com/bnb-chain/revm?rev=add28b2bb131aa4a37ab4daf817e46448158dfc8#add28b2bb131aa4a37ab4daf817e46448158dfc8"
+source = "git+https://github.com/bnb-chain/revm?tag=v1.0.6#d66170e712460ae766fc26a063f106658ce33e9d"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -10549,7 +10549,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "14.0.0"
-source = "git+https://github.com/bnb-chain/revm?rev=add28b2bb131aa4a37ab4daf817e46448158dfc8#add28b2bb131aa4a37ab4daf817e46448158dfc8"
+source = "git+https://github.com/bnb-chain/revm?tag=v1.0.6#d66170e712460ae766fc26a063f106658ce33e9d"
 dependencies = [
  "alloy-rlp",
  "aurora-engine-modexp",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "13.0.0"
-source = "git+https://github.com/bnb-chain/revm?rev=add28b2bb131aa4a37ab4daf817e46448158dfc8#add28b2bb131aa4a37ab4daf817e46448158dfc8"
+source = "git+https://github.com/bnb-chain/revm?tag=v1.0.6#d66170e712460ae766fc26a063f106658ce33e9d"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.0.7"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT OR Apache-2.0"
@@ -625,52 +625,20 @@ tikv-jemallocator = "0.6"
 tracy-client = "0.17.3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bnb-chain/revm", rev = "add28b2bb131aa4a37ab4daf817e46448158dfc8" }
-revm-interpreter = { git = "https://github.com/bnb-chain/revm", rev = "add28b2bb131aa4a37ab4daf817e46448158dfc8" }
-revm-primitives = { git = "https://github.com/bnb-chain/revm", rev = "add28b2bb131aa4a37ab4daf817e46448158dfc8" }
-alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-consensus = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-eips = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-network = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-network-primitives = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-serde = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-signer = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-signer-local = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-provider = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-transport = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-transport-http = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-json-rpc = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-rpc-client = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-alloy-rpc-types-engine = { git = "https://github.com/bnb-chain/alloy", rev = "b6ca35f241857d220f530b2100581586bac05444" }
-#[patch.crates-io]
-#alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-#alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
-
-#op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
-#op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
-#op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
-#op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "6a042e7681b1" }
+revm = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.6" }
+revm-interpreter = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.6" }
+revm-primitives = { git = "https://github.com/bnb-chain/revm", tag = "v1.0.6" }
+alloy-rpc-types-eth = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-consensus = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-eips = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-network = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-network-primitives = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-serde = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-signer = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-signer-local = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-provider = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-transport = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-transport-http = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-json-rpc = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-rpc-client = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }
+alloy-rpc-types-engine = { git = "https://github.com/bnb-chain/alloy", tag = "v1.0.3" }


### PR DESCRIPTION
### Description

## v1.1.0

This release merges with upstream version v1.1.1, including several bug fixes.

**Key changes:**

* **Compatibility:** This version is compatible with the BSC mainnet, testnet, and opBNB mainnet, testnet.
* **Bug fixes:**  Several bug fixes are included in this release. For detailed code changes: [v1.0.7...v1.1.0](https://github.com/bnb-chain/reth/compare/v1.0.7...v1.1.0)

### Rationale

n/a
### Example

n/a
### Changes

Notable changes: 
n/a

### Potential Impacts
n/a