### PR TITLE
chore: prepare for v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.1.1
+
+This is a maintenance release for the BSC/opBNB mainnet and testnet.
+
+### Bug Fix
+
+- [#216](https://github.com/bnb-chain/reth/pull/216): fix: support of trace API
+- [#219](https://github.com/bnb-chain/reth/pull/219): fix: missing metrics issue
+
+### Docs
+
+- [#218](https://github.com/bnb-chain/reth/pull/218): docs: add Optimizing `vm.min_free_kbytes` for MDBX Storage in Reth docs
+
 ## v1.1.0
 
 This release merges with upstream version v1.1.1, including several bug fixes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "bsc-reth"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "reth-bsc-chainspec",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7215,7 +7215,7 @@ dependencies = [
 
 [[package]]
 name = "reth-auto-seal-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7246,7 +7246,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7272,7 +7272,7 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7324,7 +7324,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7359,7 +7359,7 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7399,7 +7399,7 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-chainspec"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7431,7 +7431,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7474,7 +7474,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7519,7 +7519,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-engine"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
@@ -7569,7 +7569,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-evm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7601,7 +7601,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-forks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7612,7 +7612,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-node"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "eyre",
@@ -7650,7 +7650,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7677,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7696,7 +7696,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7753,7 +7753,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
@@ -7766,7 +7766,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ahash",
  "alloy-eips",
@@ -7832,7 +7832,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7841,7 +7841,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7859,7 +7859,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7881,7 +7881,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -7892,7 +7892,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7909,7 +7909,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7920,7 +7920,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7936,7 +7936,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7959,7 +7959,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "alloy-primitives",
@@ -8027,7 +8027,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8056,7 +8056,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8072,7 +8072,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8099,7 +8099,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8123,7 +8123,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8254,7 +8254,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -8284,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "reth-execution-types",
@@ -8296,7 +8296,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "futures",
  "pin-project",
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8406,7 +8406,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8453,7 +8453,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8476,7 +8476,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "eyre",
@@ -8487,7 +8487,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8501,7 +8501,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8540,7 +8540,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8566,7 +8566,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8576,7 +8576,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8604,7 +8604,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8629,7 +8629,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8644,7 +8644,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8705,7 +8705,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8754,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8763,7 +8763,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8787,7 +8787,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes 1.7.2",
@@ -8809,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bindgen 0.70.1",
  "cc",
@@ -8838,7 +8838,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "futures",
  "metrics",
@@ -8849,14 +8849,14 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8870,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8930,7 +8930,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8952,7 +8952,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8972,7 +8972,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -9001,7 +9001,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9019,7 +9019,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9041,7 +9041,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -9108,7 +9108,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9157,7 +9157,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9204,7 +9204,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9227,7 +9227,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "eyre",
  "http 1.1.0",
@@ -9252,7 +9252,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9264,7 +9264,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9330,7 +9330,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9346,7 +9346,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9374,7 +9374,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9385,7 +9385,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -9431,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9465,7 +9465,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9474,7 +9474,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "reth-codecs",
  "reth-db-api",
@@ -9525,7 +9525,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -9546,7 +9546,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9568,7 +9568,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-rpc-types",
  "reth-chainspec",
@@ -9578,7 +9578,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9623,7 +9623,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9651,7 +9651,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9700,7 +9700,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -9729,7 +9729,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9749,7 +9749,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9766,7 +9766,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9839,7 +9839,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -9865,7 +9865,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9885,7 +9885,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9936,7 +9936,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9972,7 +9972,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10015,7 +10015,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10059,7 +10059,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.1.0",
@@ -10074,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10089,7 +10089,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types-compat"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10106,7 +10106,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10156,7 +10156,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -10184,7 +10184,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10201,7 +10201,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10223,7 +10223,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10253,7 +10253,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10265,7 +10265,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10282,7 +10282,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10295,7 +10295,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10318,7 +10318,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10363,7 +10363,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10392,7 +10392,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10416,7 +10416,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10445,7 +10445,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10472,7 +10472,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-prefetch"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10499,7 +10499,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Description

## v1.1.1

This is a maintenance release for the BSC/opBNB mainnet and testnet.

### Bug Fix

- [#216](https://github.com/bnb-chain/reth/pull/216): fix: support of trace API
- [#219](https://github.com/bnb-chain/reth/pull/219): fix: missing metrics issue

### Docs

- [#218](https://github.com/bnb-chain/reth/pull/218): docs: add Optimizing `vm.min_free_kbytes` for MDBX Storage in Reth docs


### Rationale

n/a
### Example

n/a
### Changes

Notable changes: 
n/a

### Potential Impacts
n/a