### PR TITLE
release: prepare for v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.1.1
+
+This is a maintenance release for the BSC/opBNB mainnet and testnet.
+
+### Bug Fix
+
+- [#216](https://github.com/bnb-chain/reth/pull/216): fix: support of trace API
+- [#219](https://github.com/bnb-chain/reth/pull/219): fix: missing metrics issue
+
+### Docs
+
+- [#218](https://github.com/bnb-chain/reth/pull/218): docs: add Optimizing `vm.min_free_kbytes` for MDBX Storage in Reth docs
+
 ## v1.1.0
 
 This release merges with upstream version v1.1.1, including several bug fixes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "bsc-reth"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "reth-bsc-chainspec",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7215,7 +7215,7 @@ dependencies = [
 
 [[package]]
 name = "reth-auto-seal-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7246,7 +7246,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7272,7 +7272,7 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7324,7 +7324,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7359,7 +7359,7 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7399,7 +7399,7 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-chainspec"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7431,7 +7431,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7474,7 +7474,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7519,7 +7519,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-engine"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
@@ -7569,7 +7569,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-evm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7601,7 +7601,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-forks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7612,7 +7612,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-node"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "eyre",
@@ -7650,7 +7650,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7677,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bsc-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7696,7 +7696,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7753,7 +7753,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
@@ -7766,7 +7766,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ahash",
  "alloy-eips",
@@ -7832,7 +7832,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7841,7 +7841,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7859,7 +7859,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7881,7 +7881,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -7892,7 +7892,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7909,7 +7909,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7920,7 +7920,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7936,7 +7936,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7959,7 +7959,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "alloy-primitives",
@@ -8027,7 +8027,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8056,7 +8056,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8072,7 +8072,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8099,7 +8099,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8123,7 +8123,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8254,7 +8254,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -8284,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "reth-execution-types",
@@ -8296,7 +8296,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "futures",
  "pin-project",
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8406,7 +8406,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8453,7 +8453,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8476,7 +8476,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "eyre",
@@ -8487,7 +8487,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8501,7 +8501,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8540,7 +8540,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8566,7 +8566,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8576,7 +8576,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8604,7 +8604,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8629,7 +8629,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8644,7 +8644,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8705,7 +8705,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8754,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8763,7 +8763,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8787,7 +8787,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes 1.7.2",
@@ -8809,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bindgen 0.70.1",
  "cc",
@@ -8838,7 +8838,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "futures",
  "metrics",
@@ -8849,14 +8849,14 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8870,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8930,7 +8930,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8952,7 +8952,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8972,7 +8972,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -9001,7 +9001,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9019,7 +9019,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9041,7 +9041,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -9108,7 +9108,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9157,7 +9157,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9204,7 +9204,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9227,7 +9227,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "eyre",
  "http 1.1.0",
@@ -9252,7 +9252,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9264,7 +9264,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9330,7 +9330,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9346,7 +9346,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9374,7 +9374,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9385,7 +9385,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -9431,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9465,7 +9465,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9474,7 +9474,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "reth-codecs",
  "reth-db-api",
@@ -9525,7 +9525,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -9546,7 +9546,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9568,7 +9568,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-rpc-types",
  "reth-chainspec",
@@ -9578,7 +9578,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9623,7 +9623,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9651,7 +9651,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9700,7 +9700,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -9729,7 +9729,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9749,7 +9749,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9766,7 +9766,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9839,7 +9839,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -9865,7 +9865,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9885,7 +9885,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9936,7 +9936,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9972,7 +9972,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10015,7 +10015,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10059,7 +10059,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.1.0",
@@ -10074,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10089,7 +10089,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types-compat"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10106,7 +10106,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10156,7 +10156,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -10184,7 +10184,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10201,7 +10201,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10223,7 +10223,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10253,7 +10253,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10265,7 +10265,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10282,7 +10282,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10295,7 +10295,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10318,7 +10318,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10363,7 +10363,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10392,7 +10392,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10416,7 +10416,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10445,7 +10445,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10472,7 +10472,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-prefetch"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10499,7 +10499,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5442,7 +5442,7 @@ dependencies = [
  "base64 0.22.1",
  "indexmap 2.6.0",
  "metrics",
- "metrics-util",
+ "metrics-util 0.18.0",
  "quanta",
  "thiserror",
 ]
@@ -5475,6 +5475,15 @@ dependencies = [
  "metrics",
  "quanta",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
+dependencies = [
+ "metrics",
 ]
 
 [[package]]
@@ -7582,6 +7591,8 @@ dependencies = [
  "reth-provider",
  "reth-prune-types",
  "reth-revm",
+ "reth-trie-db",
+ "revm",
  "revm-primitives",
  "thiserror",
  "tokio",
@@ -7603,6 +7614,7 @@ dependencies = [
 name = "reth-bsc-node"
 version = "1.1.0"
 dependencies = [
+ "clap",
  "eyre",
  "futures",
  "futures-util",
@@ -7630,6 +7642,7 @@ dependencies = [
  "reth-rpc",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie",
  "reth-trie-db",
  "serde_json",
  "tokio",
@@ -9222,7 +9235,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
- "metrics-util",
+ "metrics-util 0.19.0",
  "procfs 0.16.0",
  "reqwest 0.12.8",
  "reth-db-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -553,8 +553,8 @@ zstd = "0.13"
 metrics = "0.24.0"
 metrics-derive = "0.1"
 metrics-exporter-prometheus = { version = "0.16.0", default-features = false }
-metrics-process = { version = "2.3.1"} 
-metrics-util = { default-features = false, version = "0.18.0" }
+metrics-process = "2.1.0"
+metrics-util = { default-features = false, version = "0.19.0" }
 
 # proc-macros
 proc-macro2 = "1.0"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,48 @@ Or, opt for installing op-reth with the command:
 make install-op
 ```
 
+## Before setting up the node
+
+### Optimizing `vm.min_free_kbytes` for MDBX Storage in Reth
+
+#### Why Adjust `vm.min_free_kbytes`?
+
+Reth uses **MDBX** as its underlying storage engine, which relies on **memory-mapped I/O (mmap)** for high-performance operations. However, MDBX can consume a significant amount of memory, and in scenarios where applications allocate memory aggressively, the system may run into **memory pressure**.
+
+By increasing `vm.min_free_kbytes`, you can **prevent the Linux OOM (Out-Of-Memory) killer** from terminating essential processes when free memory runs low. This ensures smoother performance and better stability.
+
+#### Recommended Setting
+
+We recommend setting `vm.min_free_kbytes` to at least **4GB (4194304 kbytes)** to ensure system stability when using MDBX.
+
+#### **Linux**
+
+To apply the setting temporarily (until reboot):
+
+```sh
+sudo sysctl -w vm.min_free_kbytes=4194304
+```
+
+To make it persist across reboots, add the following line to /etc/sysctl.conf:
+
+```sh
+echo "vm.min_free_kbytes=4194304" | sudo tee -a /etc/sysctl.conf
+```
+
+Then apply the changes:
+
+```sh
+sudo sysctl -p
+```
+
+### Verifying the Configuration
+
+To verify that the setting has been applied correctly, run:
+
+```sh
+cat /proc/sys/vm/min_free_kbytes
+```
+
 ## Run Reth for BSC
 
 ### Hardware Requirements

--- a/crates/bsc/evm/Cargo.toml
+++ b/crates/bsc/evm/Cargo.toml
@@ -18,8 +18,12 @@ reth-errors.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
 reth-prune-types.workspace = true
-reth-revm.workspace = true
 reth-provider.workspace = true
+reth-revm = { workspace = true, features = ["std"] }
+reth-trie-db.workspace = true
+
+# revm with required ethereum, bsc features
+revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg"] }
 
 # bsc
 reth-bsc-consensus.workspace = true

--- a/crates/bsc/node/Cargo.toml
+++ b/crates/bsc/node/Cargo.toml
@@ -26,7 +26,8 @@ reth-primitives.workspace = true
 reth-config.workspace = true
 reth-rpc.workspace = true
 reth-node-api.workspace = true
-reth-trie-db.workspace = true
+reth-trie = { workspace = true, features = ["metrics"] }
+reth-trie-db = { workspace = true, features = ["metrics"] }
 
 # bsc-reth
 reth-bsc-chainspec.workspace = true
@@ -36,6 +37,7 @@ reth-bsc-payload-builder.workspace = true
 reth-bsc-engine.workspace = true
 
 # misc
+clap = { workspace = true, features = ["derive", "env"] }
 eyre.workspace = true
 
 [dev-dependencies]

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2347,6 +2347,9 @@ where
             debug!(target: "engine::tree", pending = ?executed.block().num_hash() ,"updating pending block");
             // if the parent is the canonical head, we can insert the block as the pending block
             self.canonical_in_memory_state.set_pending_block(executed.clone());
+            // update metrics
+            debug!(target: "engine::tree", block_number, "updating canonical chain height metric");
+            self.metrics.tree.canonical_chain_height.set(block_number as f64);
         }
 
         self.state.tree_state.insert_executed(executed);

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -2,6 +2,11 @@
 
 use std::{sync::Arc, thread::available_parallelism};
 
+use crate::{
+    components::{NodeComponents, NodeComponentsBuilder},
+    hooks::OnComponentInitializedHook,
+    BuilderContext, NodeAdapter,
+};
 use alloy_primitives::{BlockNumber, B256};
 use eyre::{Context, OptionExt};
 use rayon::ThreadPoolBuilder;
@@ -34,6 +39,7 @@ use reth_node_core::{
 use reth_node_metrics::{
     chain::ChainSpecInfo,
     hooks::Hooks,
+    recorder::install_prometheus_recorder,
     server::{MetricServer, MetricServerConfig},
     version::VersionInfo,
 };
@@ -55,12 +61,6 @@ use reth_tracing::tracing::{debug, error, info, warn};
 use tokio::sync::{
     mpsc::{unbounded_channel, Receiver, UnboundedSender},
     oneshot, watch,
-};
-
-use crate::{
-    components::{NodeComponents, NodeComponentsBuilder},
-    hooks::OnComponentInitializedHook,
-    BuilderContext, NodeAdapter,
 };
 
 /// Allows to set a tree viewer for a configured blockchain provider.
@@ -511,6 +511,9 @@ where
 
     /// Starts the prometheus endpoint.
     pub async fn start_prometheus_endpoint(&self) -> eyre::Result<()> {
+        // ensure recorder runs upkeep periodically
+        install_prometheus_recorder().spawn_upkeep();
+
         let listen_addr = self.node_config().metrics;
         if let Some(addr) = listen_addr {
             info!(target: "reth::cli", "Starting metrics endpoint at {}", addr);

--- a/crates/node/metrics/src/recorder.rs
+++ b/crates/node/metrics/src/recorder.rs
@@ -3,25 +3,78 @@
 use eyre::WrapErr;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use metrics_util::layers::{PrefixLayer, Stack};
-use std::sync::LazyLock;
+use std::sync::{atomic::AtomicBool, LazyLock};
 
 /// Installs the Prometheus recorder as the global recorder.
-pub fn install_prometheus_recorder() -> &'static PrometheusHandle {
+///
+/// Note: This must be installed before any metrics are `described`.
+///
+/// Caution: This only configures the global recorder and does not spawn the exporter.
+/// Callers must run [`PrometheusRecorder::spawn_upkeep`] manually.
+pub fn install_prometheus_recorder() -> &'static PrometheusRecorder {
     &PROMETHEUS_RECORDER_HANDLE
 }
 
 /// The default Prometheus recorder handle. We use a global static to ensure that it is only
 /// installed once.
-static PROMETHEUS_RECORDER_HANDLE: LazyLock<PrometheusHandle> =
+static PROMETHEUS_RECORDER_HANDLE: LazyLock<PrometheusRecorder> =
     LazyLock::new(|| PrometheusRecorder::install().unwrap());
 
-/// Prometheus recorder installer
+/// A handle to the Prometheus recorder.
+///
+/// This is intended to be used as the global recorder.
+/// Callers must ensure that [`PrometheusRecorder::spawn_upkeep`] is called once.
 #[derive(Debug)]
-pub struct PrometheusRecorder;
+pub struct PrometheusRecorder {
+    handle: PrometheusHandle,
+    upkeep: AtomicBool,
+}
 
 impl PrometheusRecorder {
+    const fn new(handle: PrometheusHandle) -> Self {
+        Self { handle, upkeep: AtomicBool::new(false) }
+    }
+
+    /// Returns a reference to the [`PrometheusHandle`].
+    pub const fn handle(&self) -> &PrometheusHandle {
+        &self.handle
+    }
+
+    /// Spawns the upkeep task if there hasn't been one spawned already.
+    ///
+    /// ## Panics
+    ///
+    /// This method must be called from within an existing Tokio runtime or it will panic.
+    ///
+    /// See also [`PrometheusHandle::run_upkeep`]
+    pub fn spawn_upkeep(&self) {
+        if self
+            .upkeep
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return;
+        }
+
+        let handle = self.handle.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                handle.run_upkeep();
+            }
+        });
+    }
+
     /// Installs Prometheus as the metrics recorder.
-    pub fn install() -> eyre::Result<PrometheusHandle> {
+    ///
+    /// Caution: This only configures the global recorder and does not spawn the exporter.
+    /// Callers must run [`Self::spawn_upkeep`] manually.
+    pub fn install() -> eyre::Result<Self> {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
 
@@ -31,7 +84,7 @@ impl PrometheusRecorder {
             .install()
             .wrap_err("Couldn't set metrics recorder.")?;
 
-        Ok(handle)
+        Ok(Self::new(handle))
     }
 }
 
@@ -52,7 +105,7 @@ mod tests {
         process.describe();
         process.collect();
 
-        let metrics = PROMETHEUS_RECORDER_HANDLE.render();
+        let metrics = PROMETHEUS_RECORDER_HANDLE.handle.render();
         assert!(metrics.contains("process_cpu_seconds_total"), "{metrics:?}");
     }
 }

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -103,7 +103,7 @@ impl MetricServer {
                 let hook = hook.clone();
                 let service = tower::service_fn(move |_| {
                     (hook)();
-                    let metrics = handle.render();
+                    let metrics = handle.handle().render();
                     let mut response = Response::new(metrics);
                     response
                         .headers_mut()

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -1,12 +1,200 @@
 //! Contains RPC handler implementations specific to tracing.
 
-use reth_evm::ConfigureEvm;
-use reth_primitives::Header;
-use reth_rpc_eth_api::helpers::{LoadState, Trace};
-
 use crate::EthApi;
+use alloy_eips::BlockId;
+use alloy_rpc_types_eth::TransactionInfo;
+use reth_bsc_primitives::system_contracts::is_system_transaction;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_evm::{system_calls::SystemCaller, ConfigureEvm};
+use reth_primitives::{Header, SealedBlockWithSenders};
+use reth_revm::database::StateProviderDatabase;
+use reth_rpc_eth_api::helpers::{LoadBlock, LoadState, SpawnBlocking, Trace};
+use reth_rpc_eth_types::{
+    cache::db::{StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},
+    EthApiError, StateCacheDb,
+};
+use revm::{db::CacheDB, Inspector};
+use revm_primitives::{
+    db::DatabaseCommit, EnvWithHandlerCfg, EvmState, ExecutionResult, ResultAndState,
+};
+use std::{future::Future, sync::Arc};
 
-impl<Provider, Pool, Network, EvmConfig> Trace for EthApi<Provider, Pool, Network, EvmConfig> where
-    Self: LoadState<Evm: ConfigureEvm<Header = Header>>
+impl<Provider, Pool, Network, EvmConfig> Trace for EthApi<Provider, Pool, Network, EvmConfig>
+where
+    Self: LoadState<Evm: ConfigureEvm<Header = Header>>,
+    Provider: ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>,
+    EvmConfig: ConfigureEvm<Header = Header>,
 {
+    #[allow(clippy::manual_async_fn)]
+    fn trace_block_until_with_inspector<Setup, Insp, F, R>(
+        &self,
+        block_id: BlockId,
+        block: Option<Arc<SealedBlockWithSenders>>,
+        highest_index: Option<u64>,
+        mut inspector_setup: Setup,
+        f: F,
+    ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
+    where
+        Self: LoadBlock,
+        F: Fn(
+                TransactionInfo,
+                Insp,
+                ExecutionResult,
+                &EvmState,
+                &StateCacheDb<'_>,
+            ) -> Result<R, Self::Error>
+            + Send
+            + 'static,
+        Setup: FnMut() -> Insp + Send + 'static,
+        Insp: for<'a, 'b> Inspector<StateCacheDbRefMutWrapper<'a, 'b>> + Send + 'static,
+        R: Send + 'static,
+    {
+        async move {
+            let block = async {
+                if block.is_some() {
+                    return Ok(block)
+                }
+                self.block_with_senders(block_id).await
+            };
+
+            let ((cfg, block_env, _), block) =
+                futures::try_join!(self.evm_env_at(block_id), block)?;
+
+            let Some(block) = block else { return Ok(None) };
+
+            if block.body.transactions.is_empty() {
+                // nothing to trace
+                return Ok(Some(Vec::new()))
+            }
+
+            let parent_timestamp = self
+                .block_with_senders(block.parent_hash.into())
+                .await?
+                .ok_or(EthApiError::HeaderNotFound(block.parent_hash.into()))?
+                .timestamp;
+
+            // replay all transactions of the block
+            self.spawn_tracing(move |this| {
+                // we need to get the state of the parent block because we're replaying this block
+                // on top of its parent block's state
+                let state_at = block.parent_hash;
+                let block_hash = block.hash();
+
+                let block_number = block_env.number.saturating_to::<u64>();
+                let base_fee = block_env.basefee.saturating_to::<u128>();
+
+                // now get the state
+                let state = this.state_at_block_id(state_at.into())?;
+                let mut db =
+                    CacheDB::new(StateProviderDatabase::new(StateProviderTraitObjWrapper(&state)));
+
+                // apply relevant system calls
+                SystemCaller::new(this.evm_config().clone(), this.provider().chain_spec())
+                    .pre_block_beacon_root_contract_call(
+                        &mut db,
+                        &cfg,
+                        &block_env,
+                        block.header().parent_beacon_block_root,
+                    )
+                    .map_err(|_| {
+                        EthApiError::EvmCustom("failed to apply 4788 system call".to_string())
+                    })?;
+
+                // prepare transactions, we do everything upfront to reduce time spent with open
+                // state
+                let max_transactions =
+                    highest_index.map_or(block.body.transactions.len(), |highest| {
+                        // we need + 1 because the index is 0-based
+                        highest as usize + 1
+                    });
+                let mut results = Vec::with_capacity(max_transactions);
+
+                let mut transactions = block
+                    .transactions_with_sender()
+                    .take(max_transactions)
+                    .enumerate()
+                    .map(|(idx, (signer, tx))| {
+                        let tx_info = TransactionInfo {
+                            hash: Some(tx.hash()),
+                            index: Some(idx as u64),
+                            block_hash: Some(block_hash),
+                            block_number: Some(block_number),
+                            base_fee: Some(base_fee),
+                        };
+                        (tx_info, signer, tx)
+                    })
+                    .peekable();
+
+                let is_bsc = this.bsc_trace_helper.is_some();
+                let mut before_system_tx = is_bsc;
+
+                // try to upgrade system contracts for bsc before all txs if feynman is not active
+                if is_bsc {
+                    if let Some(trace_helper) = this.bsc_trace_helper.as_ref() {
+                        trace_helper
+                            .upgrade_system_contracts(&mut db, &block_env, parent_timestamp, true)
+                            .map_err(|e| e.into())?;
+                    }
+                }
+
+                while let Some((tx_info, sender, tx)) = transactions.next() {
+                    // check if the transaction is a system transaction
+                    // this should be done before return
+                    if is_bsc &&
+                        before_system_tx &&
+                        is_system_transaction(tx, *sender, block_env.coinbase)
+                    {
+                        if let Some(trace_helper) = this.bsc_trace_helper.as_ref() {
+                            // move block reward from the system address to the coinbase
+                            trace_helper
+                                .add_block_reward(&mut db, &block_env)
+                                .map_err(|e| e.into())?;
+
+                            // try to upgrade system contracts between normal txs and system txs
+                            // if feynman is active
+                            trace_helper
+                                .upgrade_system_contracts(
+                                    &mut db,
+                                    &block_env,
+                                    parent_timestamp,
+                                    false,
+                                )
+                                .map_err(|e| e.into())?;
+                        }
+
+                        before_system_tx = false;
+                    }
+
+                    let tx_env = this.evm_config().tx_env(tx, *sender);
+                    #[cfg(feature = "bsc")]
+                    let tx_env = {
+                        let mut tx_env = tx_env;
+                        if !before_system_tx {
+                            tx_env.bsc.is_system_transaction = Some(true);
+                        };
+                        tx_env
+                    };
+
+                    let env =
+                        EnvWithHandlerCfg::new_with_cfg_env(cfg.clone(), block_env.clone(), tx_env);
+
+                    let mut inspector = inspector_setup();
+                    let (res, _) =
+                        this.inspect(StateCacheDbRefMutWrapper(&mut db), env, &mut inspector)?;
+                    let ResultAndState { result, state } = res;
+                    results.push(f(tx_info, inspector, result, &state, &db)?);
+
+                    // need to apply the state changes of this transaction before executing the
+                    // next transaction, but only if there's a next transaction
+                    if transactions.peek().is_some() {
+                        // commit the state changes to the DB
+                        db.commit(state)
+                    }
+                }
+
+                Ok(Some(results))
+            })
+            .await
+        }
+    }
 }


### PR DESCRIPTION
### Description

Prepare release for v1.1.1

### Rationale

## v1.1.1

This is a maintenance release for the BSC/opBNB mainnet and testnet.

### Bug Fix

- [#216](https://github.com/bnb-chain/reth/pull/216): fix: support of trace API
- [#219](https://github.com/bnb-chain/reth/pull/219): fix: missing metrics issue

### Docs

- [#218](https://github.com/bnb-chain/reth/pull/218): docs: add Optimizing `vm.min_free_kbytes` for MDBX Storage in Reth docs

### Example

NA

